### PR TITLE
Feature: format hints

### DIFF
--- a/.lint.sh
+++ b/.lint.sh
@@ -10,8 +10,6 @@ find src/ -regex "\(.*__pycache__.*\|*.py[co]\)" -delete
 
 echo "pyflakes"
 pyflakes ./src/
-# disabled until pylint supports Python 3.6
-# https://github.com/PyCQA/pylint/issues/1113
 
 echo "pylint"
 pylint -E ./src/observer/** --load-plugins=pylint_django --disable=E1103 2> /dev/null

--- a/.test.sh
+++ b/.test.sh
@@ -17,7 +17,11 @@ find src/ -name '*.pyc' -delete
 
 # called by test.sh
 #./src/manage.py test --testrunner=green.djangorunner.DjangoRunner "$@"
-coverage run --source='src/' --omit='*/tests/*,*/migrations/*' src/manage.py test "$module" --no-input
+#coverage run --source='src/' --omit='*/tests/*,*/migrations/*' src/manage.py test "$module" --no-input
+coverage run \
+    --source='src/' \
+    --omit='*/tests/*,*/migrations/*,src/core/settings.py,src/core/wsgi.py,src/manage.py,src/observer/apps.py' \
+    src/manage.py test "$module" --no-input
 #echo "* passed tests"
 
 #GREEN_CONFIG=.green ./src/manage.py test "$module" --testrunner=green.djangorunner.DjangoRunner --no-input -v 3

--- a/.test.sh
+++ b/.test.sh
@@ -29,10 +29,10 @@ if [ $print_coverage -eq 1 ]; then
     coverage report
     # is only run if tests pass
     covered=$(coverage report | grep TOTAL | awk '{print $4}' | sed 's/%//')
-    if [ $covered -lt 79 ]; then
+    if [ $covered -lt 80 ]; then
         coverage html
         echo
-        echo "FAILED this project requires at least 79% coverage, got $covered"
+        echo "FAILED this project requires at least 80% coverage, got $covered"
         echo
         exit 1
     fi

--- a/.test.sh
+++ b/.test.sh
@@ -32,7 +32,7 @@ if [ $print_coverage -eq 1 ]; then
     if [ $covered -lt 80 ]; then
         coverage html
         echo
-        echo "FAILED this project requires at least 80% coverage, got $covered"
+        echo -e "\e[31mFAILED\e[0m this project requires at least 80% coverage, got $covered"
         echo
         exit 1
     fi

--- a/smoke_tests.sh
+++ b/smoke_tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -ex
 
-for path in / /report/latest-articles/ /report/upcoming-articles/; do
+for path in / /report/latest-articles /report/upcoming-articles; do
     [ $(curl --write-out %{http_code} --silent --output /dev/null https://$(hostname)$path) == 200 ]
 done
 

--- a/src/observer/csv.py
+++ b/src/observer/csv.py
@@ -1,6 +1,7 @@
 import csv as csvpy
-from datetime import datetime
-from . import utils
+from datetime import date, datetime
+from . import models, utils
+from functools import partial
 
 # https://docs.djangoproject.com/en/1.11/howto/outputting-csv/
 from django.http import StreamingHttpResponse
@@ -12,9 +13,10 @@ class Echo(object):
         """Write the value by returning it, instead of storing in a buffer."""
         return value
 
-def streaming_csv_response(filename, rows):
+def streaming_csv_response(filename, rows, writer=None):
     pseudo_buffer = Echo()
-    writer = csvpy.writer(pseudo_buffer)
+
+    writer = (writer or csvpy.writer)(pseudo_buffer)
     response = StreamingHttpResponse((writer.writerow(row) for row in rows),
                                      content_type="text/csv")
     response['Content-Disposition'] = 'attachment; filename="%s.csv"' % filename
@@ -24,13 +26,69 @@ def streaming_csv_response(filename, rows):
 #
 #
 
-def format_row(row):
+def coerce(val):
+    "coerce a value to a csv-friendly value"
+    lu = {
+        datetime: utils.ymdhms,
+        date: utils.ymd,
+    }
+    if type(val) in lu:
+        return lu[type(val)](val)
+    return val
+
+def format_dict(row):
+    # alphabetical sorting
+    return sorted(utils.val_map(coerce, row).items())
+
+def format_list(row, headers):
+    if not headers:
+        headers = range(1, len(row))
+    return zip(headers, map(coerce, row))
+    
     lu = {
         datetime: utils.ymd
     }
     return [val if not lu.get(type(val)) else lu[type(val)](val) for val in row]
 
+def format_article(art):
+    return format_dict(utils.to_dict(art))
+
+def format_row(row, context):
+    "the output of this function must be a list of pairs, [(key, val), (key, val), etc]"
+    idx = {
+        dict: format_dict,
+        models.Article: format_article,
+    }
+    default = partial(format_list, context.get('headers'))
+    return idx.get(type(row), default)(row)
+
+'''
+arghj! not getting anywhere with this code.
+
+intent is:
+
+you pass format_report a report
+a report contains an 'items' key
+'items' is a queryset
+each result in queryset is either an object, a dict or a list
+each type gets it's own formatter
+each of the values emitted needs to go through the coercer
+headers can optionally be present
+if present, use those. results are limited to the keys specified
+if not present, peek into the first row of results and use those keys, ordered alphabetically
+if not present and row is a list of values, emit no headers, assume ordering is correct
+
+
+
+'''
+
+
 def format_report(report, context):
-    rows = map(format_row, report['items'])
+    rows = map(partial(format_row, context=context), report['items'])
     filename = report['title'].replace(' ', '-').lower()
-    return streaming_csv_response(filename, rows)
+    
+    peek = next(rows)
+    headers = map(utils.first, peek)
+
+    rows = itertools.chain([peek], rows)
+    return streaming_csv_response(filename, rows, csvpy.DictWriter)

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -25,7 +25,7 @@ def report(meta):
 def article_meta(**kwargs):
     "returns standard metadata most reports returning models.Article objects will need"
     meta = {
-        SERIALISATIONS: [RSS],
+        SERIALISATIONS: [RSS, CSV],
         ORDER_BY: 'datetime_version_published',
         ORDER: DESC,
         PER_PAGE: 28,
@@ -84,7 +84,7 @@ def published_research_article_index():
     return models.Article.objects \
         .exclude(type__in=['article-commentary', 'editorial', 'book-review', 'discussion', 'correction']) \
         .order_by('msid') \
-        .values_list('msid', 'datetime_poa_published', 'datetime_vor_published')
+        .values('msid', 'datetime_poa_published', 'datetime_vor_published')
 
 #
 #

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -1,3 +1,4 @@
+import copy
 from . import models, rss, csv
 from .utils import ensure
 from functools import wraps
@@ -98,6 +99,7 @@ def format_report(report, format, context):
         CSV: csv.format_report,
     }
     ensure(format in report[SERIALISATIONS], "unsupported format %r for report %s" % (format, report))
+    report = copy.deepcopy(report)
     return known_formats[format](report, context)
 
 # replace these with some fancy introspection of the reports module

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -1,4 +1,4 @@
-from . import models
+from . import models, rss, csv
 from .utils import ensure
 from functools import wraps
 
@@ -92,7 +92,6 @@ def published_research_article_index():
 #
 
 def format_report(report, format, context):
-    from . import rss, csv
     # the report has been executed at this point
     known_formats = {
         RSS: rss.format_report,

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -1,4 +1,5 @@
 from . import models
+from .utils import ensure
 from functools import wraps
 
 # utils
@@ -84,11 +85,21 @@ def published_research_article_index():
     return models.Article.objects \
         .exclude(type__in=['article-commentary', 'editorial', 'book-review', 'discussion', 'correction']) \
         .order_by('msid') \
-        .values('msid', 'datetime_poa_published', 'datetime_vor_published')
+        .values_list('msid', 'datetime_poa_published', 'datetime_vor_published')
 
 #
 #
 #
+
+def format_report(report, format, context):
+    from . import rss, csv
+    # the report has been executed at this point
+    known_formats = {
+        RSS: rss.format_report,
+        CSV: csv.format_report,
+    }
+    ensure(format in report[SERIALISATIONS], "unsupported format %r for report %s" % (format, report))
+    return known_formats[format](report, context)
 
 # replace these with some fancy introspection of the reports module
 

--- a/src/observer/tests/base.py
+++ b/src/observer/tests/base.py
@@ -1,5 +1,16 @@
 import os
 from django.test import TestCase
+from io import StringIO
+from django.core.management import call_command as dj_call_command
+
+def call_command(*args, **kwargs):
+    stdout = StringIO()
+    try:
+        kwargs['stdout'] = stdout
+        dj_call_command(*args, **kwargs)
+    except SystemExit as err:
+        return err.code, stdout.getvalue()
+    raise AssertionError("management commands should always throw a systemexit()")
 
 class BaseCase(TestCase):
     this_dir = os.path.dirname(os.path.realpath(__file__))

--- a/src/observer/tests/fixtures/ajson/copy-fixtures.sh
+++ b/src/observer/tests/fixtures/ajson/copy-fixtures.sh
@@ -1,7 +1,0 @@
-#!/bin/bash
-set -xuv
-for fname in 13964 14850 15378 18675
-do
-   cp "/home/luke/dev/python/bot-lax-adaptor/article-json/elife-$fname"* ./
-done
-

--- a/src/observer/tests/fixtures/ajson/elife-13964-v2.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-13964-v2.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-13964-v2.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-13964-v2.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-05-16T00:00:00Z",
   "volume": 5,
   "elocationId": "e13964",
-  "pdf": "https://publishing-cdn.elifesciences.org/13964/elife-13964-v2.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/13964/elife-13964-v2.pdf",
   "subjects": [
     {
       "id": "cancer-biology",
@@ -749,7 +749,7 @@
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-supp-v2.zip",
+      "uri": "https://cdn.elifesciences.org/articles/13964/elife-13964-supp-v2.zip",
       "filename": "elife-13964-supp-v2.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."

--- a/src/observer/tests/fixtures/ajson/elife-13964-v3.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-13964-v3.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-13964-v3.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-13964-v3.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-05-16T00:00:00Z",
   "volume": 5,
   "elocationId": "e13964",
-  "pdf": "https://publishing-cdn.elifesciences.org/13964/elife-13964-v3.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/13964/elife-13964-v3.pdf",
   "subjects": [
     {
       "id": "cancer-biology",
@@ -1008,7 +1008,7 @@
       "label": "Supplementary file 1.",
       "title": "shRNA screen hits selective to ERG-positive prostate cancer",
       "mediaType": "application/xlsx",
-      "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-supp1-v3.xlsx",
+      "uri": "https://cdn.elifesciences.org/articles/13964/elife-13964-supp1-v3.xlsx",
       "filename": "elife-13964-supp1-v3.xlsx"
     },
     {
@@ -1017,7 +1017,7 @@
       "label": "Supplementary file 2.",
       "title": "List of candidate ERG protein interactors identified by Mass Spectrometry analysis of an ERG pulldown",
       "mediaType": "application/xlsx",
-      "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-supp2-v3.xlsx",
+      "uri": "https://cdn.elifesciences.org/articles/13964/elife-13964-supp2-v3.xlsx",
       "filename": "elife-13964-supp2-v3.xlsx"
     },
     {
@@ -1026,7 +1026,7 @@
       "label": "Supplementary file 3.",
       "title": "PRMT5 activated pathways",
       "mediaType": "application/xlsx",
-      "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-supp3-v3.xlsx",
+      "uri": "https://cdn.elifesciences.org/articles/13964/elife-13964-supp3-v3.xlsx",
       "filename": "elife-13964-supp3-v3.xlsx"
     }
   ],
@@ -1146,16 +1146,15 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-v3.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-v3.tif/full/full/0/default.jpg",
               "filename": "elife-13964-fig1-v3.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-v3.tif",
             "size": {
               "width": 2439,
               "height": 2770
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-v3.jpg",
-            "filename": "elife-13964-fig1-v3.jpg"
+            }
           },
           "supplements": [
             {
@@ -1173,23 +1172,18 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-figsupp1-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-figsupp1-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig1-figsupp1-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-figsupp1-v3.tif",
                 "size": {
                   "width": 2232,
                   "height": 2871
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig1-figsupp1-v3.jpg",
-                "filename": "elife-13964-fig1-figsupp1-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig1-figsupp1-v3.jpg",
-              "alt": ""
+                }
+              }
             }
-          ],
-          "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig1-v3.jpg",
-          "alt": ""
+          ]
         },
         {
           "type": "paragraph",
@@ -1222,16 +1216,15 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-v3.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-v3.tif/full/full/0/default.jpg",
               "filename": "elife-13964-fig2-v3.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-v3.tif",
             "size": {
               "width": 2451,
               "height": 3023
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-v3.jpg",
-            "filename": "elife-13964-fig2-v3.jpg"
+            }
           },
           "supplements": [
             {
@@ -1249,19 +1242,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp1-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp1-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig2-figsupp1-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp1-v3.tif",
                 "size": {
                   "width": 2338,
                   "height": 864
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp1-v3.jpg",
-                "filename": "elife-13964-fig2-figsupp1-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig2-figsupp1-v3.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "image",
@@ -1278,19 +1268,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp2-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp2-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig2-figsupp2-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp2-v3.tif",
                 "size": {
                   "width": 2172,
                   "height": 2756
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp2-v3.jpg",
-                "filename": "elife-13964-fig2-figsupp2-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig2-figsupp2-v3.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "image",
@@ -1307,23 +1294,18 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp3-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp3-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig2-figsupp3-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp3-v3.tif",
                 "size": {
                   "width": 2330,
                   "height": 2434
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig2-figsupp3-v3.jpg",
-                "filename": "elife-13964-fig2-figsupp3-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig2-figsupp3-v3.jpg",
-              "alt": ""
+                }
+              }
             }
-          ],
-          "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig2-v3.jpg",
-          "alt": ""
+          ]
         },
         {
           "type": "paragraph",
@@ -1352,16 +1334,15 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-v3.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-v3.tif/full/full/0/default.jpg",
               "filename": "elife-13964-fig3-v3.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-v3.tif",
             "size": {
               "width": 2433,
               "height": 2911
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-v3.jpg",
-            "filename": "elife-13964-fig3-v3.jpg"
+            }
           },
           "supplements": [
             {
@@ -1379,19 +1360,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp1-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp1-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig3-figsupp1-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp1-v3.tif",
                 "size": {
                   "width": 1630,
                   "height": 700
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp1-v3.jpg",
-                "filename": "elife-13964-fig3-figsupp1-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig3-figsupp1-v3.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "image",
@@ -1408,19 +1386,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp2-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp2-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig3-figsupp2-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp2-v3.tif",
                 "size": {
                   "width": 2285,
                   "height": 1340
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp2-v3.jpg",
-                "filename": "elife-13964-fig3-figsupp2-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig3-figsupp2-v3.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "image",
@@ -1437,23 +1412,18 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp3-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp3-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig3-figsupp3-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp3-v3.tif",
                 "size": {
                   "width": 2095,
                   "height": 2574
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig3-figsupp3-v3.jpg",
-                "filename": "elife-13964-fig3-figsupp3-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig3-figsupp3-v3.jpg",
-              "alt": ""
+                }
+              }
             }
-          ],
-          "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig3-v3.jpg",
-          "alt": ""
+          ]
         },
         {
           "type": "paragraph",
@@ -1482,16 +1452,15 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-v3.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-v3.tif/full/full/0/default.jpg",
               "filename": "elife-13964-fig4-v3.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-v3.tif",
             "size": {
               "width": 2027,
               "height": 2836
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-v3.jpg",
-            "filename": "elife-13964-fig4-v3.jpg"
+            }
           },
           "supplements": [
             {
@@ -1509,23 +1478,18 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-figsupp1-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-figsupp1-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-13964-fig4-figsupp1-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-figsupp1-v3.tif",
                 "size": {
                   "width": 1734,
                   "height": 2485
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-fig4-figsupp1-v3.jpg",
-                "filename": "elife-13964-fig4-figsupp1-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig4-figsupp1-v3.jpg",
-              "alt": ""
+                }
+              }
             }
-          ],
-          "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-fig4-v3.jpg",
-          "alt": ""
+          ]
         },
         {
           "type": "paragraph",
@@ -5008,19 +4972,16 @@
         "image": {
           "source": {
             "mediaType": "image/jpeg",
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-resp-fig1-v3.jpg/full/full/0/default.jpg",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-resp-fig1-v3.tif/full/full/0/default.jpg",
             "filename": "elife-13964-resp-fig1-v3.jpg"
           },
           "alt": "",
+          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-resp-fig1-v3.tif",
           "size": {
             "width": 1535,
             "height": 879
-          },
-          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:13964/elife-13964-resp-fig1-v3.jpg",
-          "filename": "elife-13964-resp-fig1-v3.jpg"
-        },
-        "uri": "https://publishing-cdn.elifesciences.org/13964/elife-13964-resp-fig1-v3.jpg",
-        "alt": ""
+          }
+        }
       },
       {
         "type": "paragraph",

--- a/src/observer/tests/fixtures/ajson/elife-14850-v1.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-14850-v1.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-14850-v1.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-14850-v1.xml",
     "patched": true
   },
   "-history": {
@@ -18,7 +18,7 @@
   "versionDate": "2016-07-21T00:00:00Z",
   "volume": 5,
   "elocationId": "e14850",
-  "pdf": "https://publishing-cdn.elifesciences.org/14850/elife-14850-v1.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/14850/elife-14850-v1.pdf",
   "subjects": [
     {
       "id": "cell-biology",
@@ -423,19 +423,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig1-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig1-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig1-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig1-v1.tif",
                 "size": {
                   "width": 3239,
                   "height": 3506
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig1-v1.jpg",
-                "filename": "elife-14850-fig1-v1.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig1-v1.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "video",
@@ -450,7 +447,7 @@
                 }
               ],
               "width": 528,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media1.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media1.jpg",
               "height": 181,
               "sources": [
                 {
@@ -473,7 +470,6 @@
                   "filename": "elife-14850-media1.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media1.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media1.jpg",
                 "size": {
                   "width": 528,
@@ -498,7 +494,7 @@
                 }
               ],
               "width": 480,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media2.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media2.jpg",
               "height": 138,
               "sources": [
                 {
@@ -521,7 +517,6 @@
                   "filename": "elife-14850-media2.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media2.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media2.jpg",
                 "size": {
                   "width": 480,
@@ -555,16 +550,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig2-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-v1.tif",
                 "size": {
                   "width": 3143,
                   "height": 3635
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-v1.jpg",
-                "filename": "elife-14850-fig2-v1.jpg"
+                }
               },
               "supplements": [
                 {
@@ -582,23 +576,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-figsupp1-v1.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-figsupp1-v1.tif/full/full/0/default.jpg",
                       "filename": "elife-14850-fig2-figsupp1-v1.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-figsupp1-v1.tif",
                     "size": {
                       "width": 3136,
                       "height": 3466
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig2-figsupp1-v1.jpg",
-                    "filename": "elife-14850-fig2-figsupp1-v1.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig2-figsupp1-v1.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig2-v1.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "video",
@@ -613,7 +602,7 @@
                 }
               ],
               "width": 960,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media3.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media3.jpg",
               "height": 305,
               "sources": [
                 {
@@ -636,7 +625,6 @@
                   "filename": "elife-14850-media3.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media3.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media3.jpg",
                 "size": {
                   "width": 960,
@@ -661,7 +649,7 @@
                 }
               ],
               "width": 400,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media4.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media4.jpg",
               "height": 150,
               "sources": [
                 {
@@ -684,7 +672,6 @@
                   "filename": "elife-14850-media4.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media4.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media4.jpg",
                 "size": {
                   "width": 400,
@@ -705,7 +692,7 @@
                 }
               ],
               "width": 512,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media5.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media5.jpg",
               "height": 179,
               "sources": [
                 {
@@ -728,7 +715,6 @@
                   "filename": "elife-14850-media5.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media5.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media5.jpg",
                 "size": {
                   "width": 512,
@@ -766,19 +752,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig3-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig3-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig3-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig3-v1.tif",
                 "size": {
                   "width": 3154,
                   "height": 4091
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig3-v1.jpg",
-                "filename": "elife-14850-fig3-v1.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig3-v1.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "paragraph",
@@ -797,7 +780,7 @@
                 }
               ],
               "width": 336,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media6.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media6.jpg",
               "height": 323,
               "sources": [
                 {
@@ -820,7 +803,6 @@
                   "filename": "elife-14850-media6.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media6.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media6.jpg",
                 "size": {
                   "width": 336,
@@ -845,7 +827,7 @@
                 }
               ],
               "width": 768,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media7.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media7.jpg",
               "height": 238,
               "sources": [
                 {
@@ -868,7 +850,6 @@
                   "filename": "elife-14850-media7.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media7.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media7.jpg",
                 "size": {
                   "width": 768,
@@ -909,7 +890,7 @@
                 }
               ],
               "width": 592,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media8.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media8.jpg",
               "height": 196,
               "sources": [
                 {
@@ -932,7 +913,6 @@
                   "filename": "elife-14850-media8.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media8.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media8.jpg",
                 "size": {
                   "width": 592,
@@ -966,19 +946,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig4-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig4-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig4-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig4-v1.tif",
                 "size": {
                   "width": 3203,
                   "height": 4106
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig4-v1.jpg",
-                "filename": "elife-14850-fig4-v1.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig4-v1.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "video",
@@ -993,7 +970,7 @@
                 }
               ],
               "width": 1200,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media9.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media9.jpg",
               "height": 364,
               "sources": [
                 {
@@ -1016,7 +993,6 @@
                   "filename": "elife-14850-media9.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media9.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media9.jpg",
                 "size": {
                   "width": 1200,
@@ -1050,16 +1026,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig5-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-v1.tif",
                 "size": {
                   "width": 2845,
                   "height": 2789
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-v1.jpg",
-                "filename": "elife-14850-fig5-v1.jpg"
+                }
               },
               "supplements": [
                 {
@@ -1077,23 +1052,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-figsupp1-v1.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-figsupp1-v1.tif/full/full/0/default.jpg",
                       "filename": "elife-14850-fig5-figsupp1-v1.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-figsupp1-v1.tif",
                     "size": {
                       "width": 1902,
                       "height": 3333
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig5-figsupp1-v1.jpg",
-                    "filename": "elife-14850-fig5-figsupp1-v1.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig5-figsupp1-v1.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig5-v1.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -1129,16 +1099,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig6-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-v1.tif",
                 "size": {
                   "width": 2418,
                   "height": 2926
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-v1.jpg",
-                "filename": "elife-14850-fig6-v1.jpg"
+                }
               },
               "supplements": [
                 {
@@ -1156,19 +1125,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp1-v1.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp1-v1.tif/full/full/0/default.jpg",
                       "filename": "elife-14850-fig6-figsupp1-v1.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp1-v1.tif",
                     "size": {
                       "width": 3233,
                       "height": 2593
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp1-v1.jpg",
-                    "filename": "elife-14850-fig6-figsupp1-v1.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig6-figsupp1-v1.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -1185,23 +1151,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp2-v1.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp2-v1.tif/full/full/0/default.jpg",
                       "filename": "elife-14850-fig6-figsupp2-v1.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp2-v1.tif",
                     "size": {
                       "width": 1878,
                       "height": 1931
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig6-figsupp2-v1.jpg",
-                    "filename": "elife-14850-fig6-figsupp2-v1.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig6-figsupp2-v1.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig6-v1.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "video",
@@ -1216,7 +1177,7 @@
                 }
               ],
               "width": 320,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media10.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media10.jpg",
               "height": 156,
               "sources": [
                 {
@@ -1239,7 +1200,6 @@
                   "filename": "elife-14850-media10.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media10.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media10.jpg",
                 "size": {
                   "width": 320,
@@ -1303,7 +1263,7 @@
                 }
               ],
               "width": 352,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media11.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media11.jpg",
               "height": 200,
               "sources": [
                 {
@@ -1326,7 +1286,6 @@
                   "filename": "elife-14850-media11.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media11.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media11.jpg",
                 "size": {
                   "width": 352,
@@ -1353,19 +1312,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig7-v1.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig7-v1.tif/full/full/0/default.jpg",
                   "filename": "elife-14850-fig7-v1.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig7-v1.tif",
                 "size": {
                   "width": 2446,
                   "height": 3004
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig7-v1.jpg",
-                "filename": "elife-14850-fig7-v1.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig7-v1.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "paragraph",
@@ -1384,7 +1340,7 @@
                 }
               ],
               "width": 384,
-              "image": "https://publishing-cdn.elifesciences.org/14850/elife-14850-media12.jpg",
+              "image": "https://cdn.elifesciences.org/articles/14850/elife-14850-media12.jpg",
               "height": 198,
               "sources": [
                 {
@@ -1407,7 +1363,6 @@
                   "filename": "elife-14850-media12.jpg"
                 },
                 "alt": "",
-                "filename": "elife-14850-media12.jpg",
                 "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-media12.jpg",
                 "size": {
                   "width": 384,
@@ -1451,19 +1406,16 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig8-v1.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig8-v1.tif/full/full/0/default.jpg",
               "filename": "elife-14850-fig8-v1.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig8-v1.tif",
             "size": {
               "width": 3270,
               "height": 2633
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:14850/elife-14850-fig8-v1.jpg",
-            "filename": "elife-14850-fig8-v1.jpg"
-          },
-          "uri": "https://publishing-cdn.elifesciences.org/14850/elife-14850-fig8-v1.jpg",
-          "alt": ""
+            }
+          }
         },
         {
           "type": "paragraph",

--- a/src/observer/tests/fixtures/ajson/elife-15378-v1.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-15378-v1.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-15378-v1.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-15378-v1.xml",
     "patched": true
   },
   "-history": {
@@ -18,7 +18,7 @@
   "versionDate": "2016-07-29T00:00:00Z",
   "volume": 5,
   "elocationId": "e15378",
-  "pdf": "https://publishing-cdn.elifesciences.org/15378/elife-15378-v1.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/15378/elife-15378-v1.pdf",
   "subjects": [
     {
       "id": "neuroscience",
@@ -301,7 +301,7 @@
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-supp-v1.zip",
+      "uri": "https://cdn.elifesciences.org/articles/15378/elife-15378-supp-v1.zip",
       "filename": "elife-15378-supp-v1.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."

--- a/src/observer/tests/fixtures/ajson/elife-15378-v2.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-15378-v2.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-15378-v2.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-15378-v2.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-07-29T00:00:00Z",
   "volume": 5,
   "elocationId": "e15378",
-  "pdf": "https://publishing-cdn.elifesciences.org/15378/elife-15378-v2.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/15378/elife-15378-v2.pdf",
   "subjects": [
     {
       "id": "neuroscience",
@@ -455,19 +455,16 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v2.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v2.tif/full/full/0/default.jpg",
               "filename": "elife-15378-fig1-v2.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v2.tif",
             "size": {
               "width": 1685,
               "height": 1983
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v2.jpg",
-            "filename": "elife-15378-fig1-v2.jpg"
-          },
-          "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig1-v2.jpg",
-          "alt": ""
+            }
+          }
         },
         {
           "type": "paragraph",
@@ -497,16 +494,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v2.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v2.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig2-v2.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v2.tif",
                 "size": {
                   "width": 2011,
                   "height": 1610
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v2.jpg",
-                "filename": "elife-15378-fig2-v2.jpg"
+                }
               },
               "supplements": [
                 {
@@ -518,19 +514,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v2.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v2.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig2-figsupp1-v2.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v2.tif",
                     "size": {
                       "width": 1651,
                       "height": 658
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v2.jpg",
-                    "filename": "elife-15378-fig2-figsupp1-v2.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-figsupp1-v2.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -547,23 +540,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v2.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v2.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig2-figsupp2-v2.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v2.tif",
                     "size": {
                       "width": 1921,
                       "height": 761
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v2.jpg",
-                    "filename": "elife-15378-fig2-figsupp2-v2.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-figsupp2-v2.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-v2.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -584,16 +572,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v2.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v2.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig3-v2.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v2.tif",
                 "size": {
                   "width": 1976,
                   "height": 583
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v2.jpg",
-                "filename": "elife-15378-fig3-v2.jpg"
+                }
               },
               "supplements": [
                 {
@@ -611,19 +598,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v2.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v2.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp1-v2.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v2.tif",
                     "size": {
                       "width": 1493,
                       "height": 726
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v2.jpg",
-                    "filename": "elife-15378-fig3-figsupp1-v2.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp1-v2.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -640,19 +624,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v2.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v2.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp2-v2.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v2.tif",
                     "size": {
                       "width": 1475,
                       "height": 1253
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v2.jpg",
-                    "filename": "elife-15378-fig3-figsupp2-v2.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp2-v2.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -669,23 +650,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v2.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v2.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp3-v2.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v2.tif",
                     "size": {
                       "width": 1921,
                       "height": 1346
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v2.jpg",
-                    "filename": "elife-15378-fig3-figsupp3-v2.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp3-v2.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-v2.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -741,19 +717,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v2.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v2.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig4-v2.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v2.tif",
                 "size": {
                   "width": 1534,
                   "height": 1099
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v2.jpg",
-                "filename": "elife-15378-fig4-v2.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig4-v2.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "paragraph",
@@ -797,19 +770,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v2.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v2.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig5-v2.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v2.tif",
                 "size": {
                   "width": 2247,
                   "height": 1140
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v2.jpg",
-                "filename": "elife-15378-fig5-v2.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig5-v2.jpg",
-              "alt": ""
+                }
+              }
             }
           ]
         },
@@ -837,19 +807,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v2.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v2.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig6-v2.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v2.tif",
                 "size": {
                   "width": 1221,
                   "height": 1830
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v2.jpg",
-                "filename": "elife-15378-fig6-v2.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig6-v2.jpg",
-              "alt": ""
+                }
+              }
             }
           ]
         }
@@ -3810,19 +3777,16 @@
         "image": {
           "source": {
             "mediaType": "image/jpeg",
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v2.jpg/full/full/0/default.jpg",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v2.tif/full/full/0/default.jpg",
             "filename": "elife-15378-resp-fig1-v2.jpg"
           },
           "alt": "",
+          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v2.tif",
           "size": {
             "width": 727,
             "height": 579
-          },
-          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v2.jpg",
-          "filename": "elife-15378-resp-fig1-v2.jpg"
-        },
-        "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-resp-fig1-v2.jpg",
-        "alt": ""
+          }
+        }
       },
       {
         "type": "paragraph",

--- a/src/observer/tests/fixtures/ajson/elife-15378-v3.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-15378-v3.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-15378-v3.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-15378-v3.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-07-29T00:00:00Z",
   "volume": 5,
   "elocationId": "e15378",
-  "pdf": "https://publishing-cdn.elifesciences.org/15378/elife-15378-v3.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/15378/elife-15378-v3.pdf",
   "subjects": [
     {
       "id": "neuroscience",
@@ -455,19 +455,16 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v3.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v3.tif/full/full/0/default.jpg",
               "filename": "elife-15378-fig1-v3.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v3.tif",
             "size": {
               "width": 1685,
               "height": 1983
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig1-v3.jpg",
-            "filename": "elife-15378-fig1-v3.jpg"
-          },
-          "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig1-v3.jpg",
-          "alt": ""
+            }
+          }
         },
         {
           "type": "paragraph",
@@ -497,16 +494,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig2-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v3.tif",
                 "size": {
                   "width": 2011,
                   "height": 1610
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-v3.jpg",
-                "filename": "elife-15378-fig2-v3.jpg"
+                }
               },
               "supplements": [
                 {
@@ -518,19 +514,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v3.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v3.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig2-figsupp1-v3.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v3.tif",
                     "size": {
                       "width": 1651,
                       "height": 658
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp1-v3.jpg",
-                    "filename": "elife-15378-fig2-figsupp1-v3.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-figsupp1-v3.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -547,23 +540,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v3.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v3.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig2-figsupp2-v3.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v3.tif",
                     "size": {
                       "width": 1921,
                       "height": 761
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig2-figsupp2-v3.jpg",
-                    "filename": "elife-15378-fig2-figsupp2-v3.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-figsupp2-v3.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig2-v3.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -584,16 +572,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig3-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v3.tif",
                 "size": {
                   "width": 1976,
                   "height": 583
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-v3.jpg",
-                "filename": "elife-15378-fig3-v3.jpg"
+                }
               },
               "supplements": [
                 {
@@ -611,19 +598,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v3.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v3.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp1-v3.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v3.tif",
                     "size": {
                       "width": 1493,
                       "height": 726
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp1-v3.jpg",
-                    "filename": "elife-15378-fig3-figsupp1-v3.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp1-v3.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -640,19 +624,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v3.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v3.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp2-v3.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v3.tif",
                     "size": {
                       "width": 1475,
                       "height": 1253
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp2-v3.jpg",
-                    "filename": "elife-15378-fig3-figsupp2-v3.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp2-v3.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -669,23 +650,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v3.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v3.tif/full/full/0/default.jpg",
                       "filename": "elife-15378-fig3-figsupp3-v3.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v3.tif",
                     "size": {
                       "width": 1921,
                       "height": 1346
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig3-figsupp3-v3.jpg",
-                    "filename": "elife-15378-fig3-figsupp3-v3.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-figsupp3-v3.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig3-v3.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -741,19 +717,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig4-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v3.tif",
                 "size": {
                   "width": 1534,
                   "height": 1099
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig4-v3.jpg",
-                "filename": "elife-15378-fig4-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig4-v3.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "paragraph",
@@ -797,19 +770,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig5-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v3.tif",
                 "size": {
                   "width": 2247,
                   "height": 1140
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig5-v3.jpg",
-                "filename": "elife-15378-fig5-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig5-v3.jpg",
-              "alt": ""
+                }
+              }
             }
           ]
         },
@@ -837,19 +807,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v3.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v3.tif/full/full/0/default.jpg",
                   "filename": "elife-15378-fig6-v3.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v3.tif",
                 "size": {
                   "width": 1221,
                   "height": 1830
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-fig6-v3.jpg",
-                "filename": "elife-15378-fig6-v3.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-fig6-v3.jpg",
-              "alt": ""
+                }
+              }
             }
           ]
         }
@@ -3810,19 +3777,16 @@
         "image": {
           "source": {
             "mediaType": "image/jpeg",
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v3.jpg/full/full/0/default.jpg",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v3.tif/full/full/0/default.jpg",
             "filename": "elife-15378-resp-fig1-v3.jpg"
           },
           "alt": "",
+          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v3.tif",
           "size": {
             "width": 727,
             "height": 579
-          },
-          "uri": "https://prod--cdn-iiif.elifesciences.org/lax:15378/elife-15378-resp-fig1-v3.jpg",
-          "filename": "elife-15378-resp-fig1-v3.jpg"
-        },
-        "uri": "https://publishing-cdn.elifesciences.org/15378/elife-15378-resp-fig1-v3.jpg",
-        "alt": ""
+          }
+        }
       },
       {
         "type": "paragraph",

--- a/src/observer/tests/fixtures/ajson/elife-18675-v1.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-18675-v1.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-18675-v1.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-18675-v1.xml",
     "patched": true
   },
   "-history": {
@@ -18,7 +18,7 @@
   "versionDate": "2016-08-23T00:00:00Z",
   "volume": 5,
   "elocationId": "e18675",
-  "pdf": "https://publishing-cdn.elifesciences.org/18675/elife-18675-v1.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/18675/elife-18675-v1.pdf",
   "subjects": [
     {
       "id": "biochemistry",
@@ -400,7 +400,7 @@
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-supp-v1.zip",
+      "uri": "https://cdn.elifesciences.org/articles/18675/elife-18675-supp-v1.zip",
       "filename": "elife-18675-supp-v1.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."

--- a/src/observer/tests/fixtures/ajson/elife-18675-v2.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-18675-v2.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-18675-v2.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-18675-v2.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-08-23T00:00:00Z",
   "volume": 5,
   "elocationId": "e18675",
-  "pdf": "https://publishing-cdn.elifesciences.org/18675/elife-18675-v2.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/18675/elife-18675-v2.pdf",
   "subjects": [
     {
       "id": "biochemistry",
@@ -399,7 +399,7 @@
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-supp-v2.zip",
+      "uri": "https://cdn.elifesciences.org/articles/18675/elife-18675-supp-v2.zip",
       "filename": "elife-18675-supp-v2.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."

--- a/src/observer/tests/fixtures/ajson/elife-18675-v3.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-18675-v3.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-18675-v3.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-18675-v3.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-08-23T00:00:00Z",
   "volume": 5,
   "elocationId": "e18675",
-  "pdf": "https://publishing-cdn.elifesciences.org/18675/elife-18675-v3.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/18675/elife-18675-v3.pdf",
   "subjects": [
     {
       "id": "biochemistry",
@@ -399,7 +399,7 @@
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-supp-v3.zip",
+      "uri": "https://cdn.elifesciences.org/articles/18675/elife-18675-supp-v3.zip",
       "filename": "elife-18675-supp-v3.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."

--- a/src/observer/tests/fixtures/ajson/elife-18675-v4.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-18675-v4.xml.json
@@ -1,6 +1,6 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/694f91de44ebc7cc61aba8be0982b7613cac8c3f/articles/elife-18675-v4.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-18675-v4.xml",
     "patched": true
   },
   "-history": {
@@ -17,7 +17,7 @@
   "published": "2016-08-23T00:00:00Z",
   "volume": 5,
   "elocationId": "e18675",
-  "pdf": "https://publishing-cdn.elifesciences.org/18675/elife-18675-v4.pdf",
+  "pdf": "https://cdn.elifesciences.org/articles/18675/elife-18675-v4.pdf",
   "subjects": [
     {
       "id": "biochemistry",
@@ -768,19 +768,16 @@
           "image": {
             "source": {
               "mediaType": "image/jpeg",
-              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig1-v4.jpg/full/full/0/default.jpg",
+              "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig1-v4.tif/full/full/0/default.jpg",
               "filename": "elife-18675-fig1-v4.jpg"
             },
             "alt": "",
+            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig1-v4.tif",
             "size": {
               "width": 1117,
               "height": 1131
-            },
-            "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig1-v4.jpg",
-            "filename": "elife-18675-fig1-v4.jpg"
-          },
-          "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig1-v4.jpg",
-          "alt": ""
+            }
+          }
         },
         {
           "type": "paragraph",
@@ -849,16 +846,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-v4.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-v4.tif/full/full/0/default.jpg",
                   "filename": "elife-18675-fig2-v4.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-v4.tif",
                 "size": {
                   "width": 2431,
                   "height": 1756
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-v4.jpg",
-                "filename": "elife-18675-fig2-v4.jpg"
+                }
               },
               "supplements": [
                 {
@@ -876,19 +872,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp1-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp1-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig2-figsupp1-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp1-v4.tif",
                     "size": {
                       "width": 2434,
                       "height": 2020
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp1-v4.jpg",
-                    "filename": "elife-18675-fig2-figsupp1-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig2-figsupp1-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -905,19 +898,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp2-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp2-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig2-figsupp2-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp2-v4.tif",
                     "size": {
                       "width": 1931,
                       "height": 2156
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp2-v4.jpg",
-                    "filename": "elife-18675-fig2-figsupp2-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig2-figsupp2-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -934,23 +924,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp3-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp3-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig2-figsupp3-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp3-v4.tif",
                     "size": {
                       "width": 1041,
                       "height": 368
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig2-figsupp3-v4.jpg",
-                    "filename": "elife-18675-fig2-figsupp3-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig2-figsupp3-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig2-v4.jpg",
-              "alt": ""
+              ]
             }
           ]
         },
@@ -978,19 +963,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig3-v4.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig3-v4.tif/full/full/0/default.jpg",
                   "filename": "elife-18675-fig3-v4.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig3-v4.tif",
                 "size": {
                   "width": 2141,
                   "height": 1774
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig3-v4.jpg",
-                "filename": "elife-18675-fig3-v4.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig3-v4.jpg",
-              "alt": ""
+                }
+              }
             }
           ]
         },
@@ -1070,19 +1052,16 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig4-v4.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig4-v4.tif/full/full/0/default.jpg",
                   "filename": "elife-18675-fig4-v4.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig4-v4.tif",
                 "size": {
                   "width": 852,
                   "height": 1537
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig4-v4.jpg",
-                "filename": "elife-18675-fig4-v4.jpg"
-              },
-              "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig4-v4.jpg",
-              "alt": ""
+                }
+              }
             },
             {
               "type": "paragraph",
@@ -1107,16 +1086,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-v4.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-v4.tif/full/full/0/default.jpg",
                   "filename": "elife-18675-fig5-v4.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-v4.tif",
                 "size": {
                   "width": 2371,
                   "height": 1926
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-v4.jpg",
-                "filename": "elife-18675-fig5-v4.jpg"
+                }
               },
               "supplements": [
                 {
@@ -1134,19 +1112,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp1-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp1-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig5-figsupp1-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp1-v4.tif",
                     "size": {
                       "width": 2315,
                       "height": 1445
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp1-v4.jpg",
-                    "filename": "elife-18675-fig5-figsupp1-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig5-figsupp1-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -1163,23 +1138,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp2-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp2-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig5-figsupp2-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp2-v4.tif",
                     "size": {
                       "width": 1967,
                       "height": 1712
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig5-figsupp2-v4.jpg",
-                    "filename": "elife-18675-fig5-figsupp2-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig5-figsupp2-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig5-v4.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",
@@ -1215,16 +1185,15 @@
               "image": {
                 "source": {
                   "mediaType": "image/jpeg",
-                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-v4.jpg/full/full/0/default.jpg",
+                  "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-v4.tif/full/full/0/default.jpg",
                   "filename": "elife-18675-fig6-v4.jpg"
                 },
                 "alt": "",
+                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-v4.tif",
                 "size": {
                   "width": 2495,
                   "height": 2666
-                },
-                "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-v4.jpg",
-                "filename": "elife-18675-fig6-v4.jpg"
+                }
               },
               "supplements": [
                 {
@@ -1242,19 +1211,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp1-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp1-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig6-figsupp1-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp1-v4.tif",
                     "size": {
                       "width": 1998,
                       "height": 2329
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp1-v4.jpg",
-                    "filename": "elife-18675-fig6-figsupp1-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig6-figsupp1-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -1271,19 +1237,16 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp2-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp2-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig6-figsupp2-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp2-v4.tif",
                     "size": {
                       "width": 1788,
                       "height": 2176
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp2-v4.jpg",
-                    "filename": "elife-18675-fig6-figsupp2-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig6-figsupp2-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 },
                 {
                   "type": "image",
@@ -1300,23 +1263,18 @@
                   "image": {
                     "source": {
                       "mediaType": "image/jpeg",
-                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp3-v4.jpg/full/full/0/default.jpg",
+                      "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp3-v4.tif/full/full/0/default.jpg",
                       "filename": "elife-18675-fig6-figsupp3-v4.jpg"
                     },
                     "alt": "",
+                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp3-v4.tif",
                     "size": {
                       "width": 1735,
                       "height": 1793
-                    },
-                    "uri": "https://prod--cdn-iiif.elifesciences.org/lax:18675/elife-18675-fig6-figsupp3-v4.jpg",
-                    "filename": "elife-18675-fig6-figsupp3-v4.jpg"
-                  },
-                  "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig6-figsupp3-v4.jpg",
-                  "alt": ""
+                    }
+                  }
                 }
-              ],
-              "uri": "https://publishing-cdn.elifesciences.org/18675/elife-18675-fig6-v4.jpg",
-              "alt": ""
+              ]
             },
             {
               "type": "paragraph",

--- a/src/observer/tests/fixtures/ajson/elife-20125-v1.xml.json
+++ b/src/observer/tests/fixtures/ajson/elife-20125-v1.xml.json
@@ -1,32 +1,32 @@
 {
   "-meta": {
-    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-13964-v1.xml",
+    "location": "https://raw.githubusercontent.com/elifesciences/elife-article-xml/60e488fb2f97bf71c6b7a2864b745f4afb1376e8/articles/elife-20125-v1.xml",
     "patched": true
   },
   "-history": {
-    "received": "2015-12-21T00:00:00Z",
-    "accepted": "2016-05-06T00:00:00Z"
+    "received": "2016-07-28T00:00:00Z",
+    "accepted": "2016-08-30T00:00:00Z"
   },
   "status": "poa",
-  "id": "13964",
+  "id": "20125",
   "version": 1,
-  "type": "short-report",
-  "doi": "10.7554/eLife.13964",
-  "authorLine": "Zineb Mounir et al",
-  "title": "ERG signaling in prostate cancer is driven through PRMT5-dependent methylation of the androgen receptor",
-  "published": "2016-05-16T00:00:00Z",
-  "versionDate": "2016-05-16T00:00:00Z",
+  "type": "research-article",
+  "doi": "10.7554/eLife.20125",
+  "authorLine": "Andrew T Timberlake et al",
+  "title": "Two locus inheritance of non-syndromic midline craniosynostosis via rare <i>SMAD6</i> and common <i>BMP2</i> alleles",
+  "published": "2016-09-08T00:00:00Z",
+  "versionDate": "2016-09-08T00:00:00Z",
   "volume": 5,
-  "elocationId": "e13964",
-  "pdf": "https://cdn.elifesciences.org/articles/13964/elife-13964-v1.pdf",
+  "elocationId": "e20125",
+  "pdf": "https://cdn.elifesciences.org/articles/20125/elife-20125-v1.pdf",
   "subjects": [
     {
-      "id": "cancer-biology",
-      "name": "Cancer Biology"
+      "id": "genes-chromosomes",
+      "name": "Genes and Chromosomes"
     },
     {
-      "id": "cell-biology",
-      "name": "Cell Biology"
+      "id": "genomics-evolutionary-biology",
+      "name": "Genomics and Evolutionary Biology"
     }
   ],
   "researchOrganisms": [
@@ -36,35 +36,37 @@
     "content": [
       {
         "type": "paragraph",
-        "text": "The <i>TMPRSS2:ERG</i> gene fusion is common in androgen receptor (AR) positive prostate cancers, yet its function remains poorly understood. From a screen for functionally relevant ERG interactors, we identify the arginine methyltransferase PRMT5. ERG recruits PRMT5 to AR-target genes, where PRMT5 methylates AR on arginine 761. This attenuates AR recruitment and transcription of genes expressed in differentiated prostate epithelium. The AR-inhibitory function of PRMT5 is restricted to <i>TMPRSS2:ERG</i>-positive prostate cancer cells. Mutation of this methylation site on AR results in a transcriptionally hyperactive AR, suggesting that the proliferative effects of ERG and PRMT5 are mediated through attenuating AR's ability to induce genes normally involved in lineage differentiation. This provides a rationale for targeting PRMT5 in <i>TMPRSS2:ERG</i> positive prostate cancers. Moreover, methylation of AR at arginine 761 highlights a mechanism for how the ERG oncogene may coax AR towards inducing proliferation versus differentiation."
+        "text": "Premature fusion of the cranial sutures (craniosynostosis), affecting 1 in 2,000 newborns, is treated surgically in infancy to prevent adverse neurologic outcomes. To identify mutations contributing to common non-syndromic midline (sagittal and metopic) craniosynostosis, we performed exome sequencing of 132 parent-offspring trios and 59 additional probands. Thirteen probands (7%) had damaging <i>de novo</i> or rare transmitted mutations in <i>SMAD6</i>, an inhibitor of BMP - induced osteoblast differentiation (P &lt; 10-20). <i>SMAD6</i> mutations nonetheless showed striking incomplete penetrance (&lt;60%). Genotypes of a common variant near <i>BMP2</i> that is strongly associated with midline craniosynostosis explained nearly all the phenotypic variation in these kindreds, with highly significant evidence of genetic interaction between these loci via both association and analysis of linkage. This epistatic interaction of rare and common variants defines the most frequent cause of midline craniosynostosis and has implications for the genetic basis of other diseases."
       }
     ]
   },
   "copyright": {
     "license": "CC-BY-4.0",
-    "holder": "Mounir et al",
+    "holder": "Timberlake et al",
     "statement": "This article is distributed under the terms of the <a href=\"http://creativecommons.org/licenses/by/4.0/\">Creative Commons Attribution License</a> permitting unrestricted use and redistribution provided that the original author and source are credited."
   },
   "authors": [
     {
       "type": "person",
       "name": {
-        "preferred": "Zineb Mounir",
-        "index": "Mounir, Zineb"
+        "preferred": "Andrew T Timberlake",
+        "index": "Timberlake, Andrew T"
       },
+      "orcid": "0000-0002-8926-9692",
       "affiliations": [
         {
           "name": [
-            "Genentech"
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "South San Francisco",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "South San Francisco"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -76,23 +78,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Joshua M Korn",
-        "index": "Korn, Joshua M"
+        "preferred": "Jungmin Choi",
+        "index": "Choi, Jungmin"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Oncology",
-            "Novartis Institutes for BioMedical Research"
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -104,23 +106,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Thomas Westerling",
-        "index": "Westerling, Thomas"
+        "preferred": "Samir Zaidi",
+        "index": "Zaidi, Samir"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Medical Oncology, Center for Functional Cancer Epigenetics, Dana-Farber Cancer Institute",
-            "Harvard Medical School"
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Boston",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Boston"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -132,23 +134,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Fallon Lin",
-        "index": "Lin, Fallon"
+        "preferred": "Qiongshi Lu",
+        "index": "Lu, Qiongshi"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Oncology",
-            "Novartis Institutes for BioMedical Research"
+            "Department of Biostatistics",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -160,23 +162,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Christina A Kirby",
-        "index": "Kirby, Christina A"
+        "preferred": "Carol Nelson-Williams",
+        "index": "Nelson-Williams, Carol"
       },
       "affiliations": [
         {
           "name": [
-            "Center for Proteomic Chemistry",
-            "Novartis Institutes for BioMedical Research"
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -188,23 +190,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Markus Schirle",
-        "index": "Schirle, Markus"
+        "preferred": "Eric D Brooks",
+        "index": "Brooks, Eric D"
       },
       "affiliations": [
         {
           "name": [
-            "Developmental and Molecular Pathways",
-            "Novartis Institutes for Biomedical Research"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -216,23 +218,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Gregg McAllister",
-        "index": "McAllister, Gregg"
+        "preferred": "Kaya Bilguvar",
+        "index": "Bilguvar, Kaya"
       },
       "affiliations": [
         {
           "name": [
-            "Developmental and Molecular Pathways",
-            "Novartis Institutes for Biomedical Research"
+            "Department of Genetics",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -244,23 +246,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Greg Hoffman",
-        "index": "Hoffman, Greg"
+        "preferred": "Irina Tikhonova",
+        "index": "Tikhonova, Irina"
       },
       "affiliations": [
         {
           "name": [
-            "Developmental and Molecular Pathways",
-            "Novartis Institutes for Biomedical Research"
+            "Yale Center for Genome Analysis",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -272,23 +274,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Nadire Ramadan",
-        "index": "Ramadan, Nadire"
+        "preferred": "Shrikant Mane",
+        "index": "Mane, Shrikant"
       },
       "affiliations": [
         {
           "name": [
-            "Developmental and Molecular Pathways",
-            "Novartis Institutes for Biomedical Research"
+            "Department of Genetics",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -300,22 +302,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Anke Hartung",
-        "index": "Hartung, Anke"
+        "preferred": "Jenny F Yang",
+        "index": "Yang, Jenny F"
       },
       "affiliations": [
         {
           "name": [
-            "Organovo"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "San Diego",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "San Diego"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -327,23 +330,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Yan Feng",
-        "index": "Feng, Yan"
+        "preferred": "Rajendra Sawh-Martinez",
+        "index": "Sawh-Martinez, Rajendra"
       },
       "affiliations": [
         {
           "name": [
-            "Developmental and Molecular Pathways",
-            "Novartis Institutes for Biomedical Research"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -355,23 +358,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "David Randal Kipp",
-        "index": "Kipp, David Randal"
+        "preferred": "Sarah Persing",
+        "index": "Persing, Sarah"
       },
       "affiliations": [
         {
           "name": [
-            "Oncology",
-            "NIBR"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -383,23 +386,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Christopher Quinn",
-        "index": "Quinn, Christopher"
+        "preferred": "Elizabeth G Zellner",
+        "index": "Zellner, Elizabeth G"
       },
       "affiliations": [
         {
           "name": [
-            "Oncology",
-            "NIBR"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -411,23 +414,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Michelle Fodor",
-        "index": "Fodor, Michelle"
+        "preferred": "Erin Loring",
+        "index": "Loring, Erin"
       },
       "affiliations": [
         {
           "name": [
-            "Oncology",
-            "NIBR"
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -439,23 +442,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Jason Baird",
-        "index": "Baird, Jason"
+        "preferred": "Carolyn Chuang",
+        "index": "Chuang, Carolyn"
       },
       "affiliations": [
         {
           "name": [
-            "Oncology",
-            "NIBR"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -467,50 +470,22 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Marie Schoumacher",
-        "index": "Schoumacher, Marie"
+        "preferred": "Amy Galm",
+        "index": "Galm, Amy"
       },
       "affiliations": [
         {
           "name": [
-            "Laboratoires Servier"
+            "Craniosynostosis and Positional Plagiocephaly Support"
           ],
           "address": {
             "formatted": [
-              "Neuilly-sur-Seine",
-              "France"
-            ],
-            "components": {
-              "locality": [
-                "Neuilly-sur-Seine"
-              ],
-              "country": "France"
-            }
-          }
-        }
-      ],
-      "competingInterests": "The authors declare that no competing interests exist."
-    },
-    {
-      "type": "person",
-      "name": {
-        "preferred": "Ronald Meyer",
-        "index": "Meyer, Ronald"
-      },
-      "affiliations": [
-        {
-          "name": [
-            "Department of Oncology",
-            "Novartis Institutes for Biomedical Research"
-          ],
-          "address": {
-            "formatted": [
-              "Cambridge",
+              "New York",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New York"
               ],
               "country": "United States"
             }
@@ -522,23 +497,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "James Deeds",
-        "index": "Deeds, James"
+        "preferred": "Peter W Hashim",
+        "index": "Hashim, Peter W"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Oncology",
-            "Novartis Institutes for Biomedical Research"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -550,22 +525,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Gilles Buchwalter",
-        "index": "Buchwalter, Gilles"
+        "preferred": "Derek M Steinbacher",
+        "index": "Steinbacher, Derek M"
       },
       "affiliations": [
         {
           "name": [
-            "Celgene Avilomics Research"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Bedford",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Bedford"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -577,23 +553,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Travis Stams",
-        "index": "Stams, Travis"
+        "preferred": "Michael L DiLuna",
+        "index": "DiLuna, Michael L"
       },
       "affiliations": [
         {
           "name": [
-            "Center for Proteomic Chemistry",
-            "Novartis Institutes for Biomedical Research"
+            "Department of Neurosurgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -605,23 +581,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Nicholas Keen",
-        "index": "Keen, Nicholas"
+        "preferred": "Charles C Duncan",
+        "index": "Duncan, Charles C"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Oncology",
-            "Novartis Institutes for Biomedical Research"
+            "Department of Neurosurgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -633,23 +609,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "William R Sellers",
-        "index": "Sellers, William R"
+        "preferred": "Kevin A Pelphrey",
+        "index": "Pelphrey, Kevin A"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Oncology",
-            "Novartis Institutes for BioMedical Research"
+            "Child Study Center",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Cambridge",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Cambridge"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -661,23 +637,23 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Myles Brown",
-        "index": "Brown, Myles"
+        "preferred": "Hongyu Zhao",
+        "index": "Zhao, Hongyu"
       },
       "affiliations": [
         {
           "name": [
-            "Department of Medical Oncology, Center for Functional Cancer Epigenetics, Dana-Farber Cancer Institute",
-            "Harvard Medical School"
+            "Department of Biostatistics",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Boston",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Boston"
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -689,22 +665,51 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Raymond A Pagliarini",
-        "index": "Pagliarini, Raymond A"
+        "preferred": "John A Persing",
+        "index": "Persing, John A"
       },
       "affiliations": [
         {
           "name": [
-            "Celgene Avilomics Research"
+            "Section of Plastic and Reconstructive Surgery, Department of Surgery",
+            "Yale University School of Medicine"
           ],
           "address": {
             "formatted": [
-              "Bedford",
+              "New Haven",
               "United States"
             ],
             "components": {
               "locality": [
-                "Bedford"
+                "New Haven"
+              ],
+              "country": "United States"
+            }
+          }
+        }
+      ],
+      "competingInterests": "The authors declare that no competing interests exist."
+    },
+    {
+      "type": "person",
+      "name": {
+        "preferred": "Richard P Lifton",
+        "index": "Lifton, Richard P"
+      },
+      "affiliations": [
+        {
+          "name": [
+            "Department of Genetics",
+            "Howard Hughes Medical Institute, Yale University School of Medicine"
+          ],
+          "address": {
+            "formatted": [
+              "New Haven",
+              "United States"
+            ],
+            "components": {
+              "locality": [
+                "New Haven"
               ],
               "country": "United States"
             }
@@ -712,7 +717,7 @@
         }
       ],
       "emailAddresses": [
-        "raymond.pagliarini@novartis.com"
+        "richard.lifton@yale.edu"
       ],
       "competingInterests": "The authors declare that no competing interests exist."
     }
@@ -721,14 +726,14 @@
     {
       "type": "person",
       "name": {
-        "preferred": "Scott A Armstrong",
-        "index": "Armstrong, Scott A"
+        "preferred": "David Ginsburg",
+        "index": "Ginsburg, David"
       },
       "role": "Reviewing Editor",
       "affiliations": [
         {
           "name": [
-            "Memorial Sloan Kettering Cancer Center"
+            "Howard Hughes Medical Institute, University of Michigan"
           ],
           "address": {
             "formatted": [
@@ -742,15 +747,115 @@
       ]
     }
   ],
+  "ethics": [
+    {
+      "type": "paragraph",
+      "text": "Human subjects: All participants or their parents provided written informed consent to participate in a study of genetic causes of craniosynostosis in their family. Written consent was obtained for publication of patient photographs. The study protocol was approved by the Yale Human Investigation Committee Institutional Review Board."
+    }
+  ],
+  "funding": {
+    "awards": [
+      {
+        "id": "par-1",
+        "source": {
+          "name": [
+            "Yale Center for Mendelian Genomics"
+          ]
+        },
+        "awardId": "NIH M#UM1HG006504-05",
+        "recipients": [
+          {
+            "type": "person",
+            "name": {
+              "preferred": "Shrikant Mane",
+              "index": "Mane, Shrikant"
+            }
+          }
+        ]
+      },
+      {
+        "id": "par-2",
+        "source": {
+          "name": [
+            "Maxillofacial Surgeons Foundation/ASMS"
+          ]
+        },
+        "awardId": "M#M156301",
+        "recipients": [
+          {
+            "type": "person",
+            "name": {
+              "preferred": "John A Persing",
+              "index": "Persing, John A"
+            }
+          }
+        ]
+      },
+      {
+        "id": "par-3",
+        "source": {
+          "name": [
+            "NIH Medical Scientist Training Program"
+          ]
+        },
+        "awardId": "NIH/NIGMS T32GM007205",
+        "recipients": [
+          {
+            "type": "person",
+            "name": {
+              "preferred": "Samir Zaidi",
+              "index": "Zaidi, Samir"
+            }
+          }
+        ]
+      },
+      {
+        "id": "par-4",
+        "source": {
+          "funderId": "10.13039/100000011",
+          "name": [
+            "Howard Hughes Medical Institute"
+          ]
+        },
+        "recipients": [
+          {
+            "type": "person",
+            "name": {
+              "preferred": "Richard P Lifton",
+              "index": "Lifton, Richard P"
+            }
+          }
+        ]
+      }
+    ],
+    "statement": "The funders had no role in study design, data collection and interpretation, or the decision to submit the work for publication."
+  },
   "additionalFiles": [
     {
       "mediaType": "application/zip",
-      "uri": "https://cdn.elifesciences.org/articles/13964/elife-13964-supp-v1.zip",
-      "filename": "elife-13964-supp-v1.zip",
+      "uri": "https://cdn.elifesciences.org/articles/20125/elife-20125-supp-v1.zip",
+      "filename": "elife-20125-supp-v1.zip",
       "id": "SD1-data",
       "title": "Supplementary file 1."
     }
   ],
+  "dataSets": {
+    "generated": [
+      {
+        "id": "dataro1",
+        "date": "2016",
+        "authors": [
+          {
+            "type": "group",
+            "name": "Timberlake et al. "
+          }
+        ],
+        "title": "Yale Center for Mendelian Genomics",
+        "details": "Publicly available at the dbGaP (accession no: phs000744)",
+        "uri": "http://www.ncbi.nlm.nih.gov/projects/gap/cgi-bin/study.cgi?study_id=phs000744.v2.p1"
+      }
+    ]
+  },
   "stage": "published",
   "statusDate": "2099-01-01T00:00:00Z"
 }

--- a/src/observer/tests/fixtures/gen-fixtures.sh
+++ b/src/observer/tests/fixtures/gen-fixtures.sh
@@ -18,4 +18,4 @@ function scrape {
     cd -
 }
 
-scrape ajson elife-13964- elife-14850- elife-15378- elife-18675-
+scrape ajson elife-13964- elife-14850- elife-15378- elife-18675- elife-20125-v1

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -10,7 +10,7 @@ class Cmd(BaseCase):
     def setUp(self):
         self.nom = 'load_from_fs'
         self.ajson_fixture = join(self.fixture_dir, 'ajson', 'elife-13964-v1.xml.json')
-        self.num_unique_articles = 4
+        self.num_unique_articles = 5
         self.temp_dir, self.temp_dir_cleaner = utils.tempdir()
 
     def tearDown(self):

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -1,9 +1,7 @@
 import os
 from os.path import join
 import json
-from .base import BaseCase
-from io import StringIO
-from django.core.management import call_command
+from .base import BaseCase, call_command
 from observer import models, utils
 
 class Cmd(BaseCase):
@@ -16,19 +14,10 @@ class Cmd(BaseCase):
     def tearDown(self):
         self.temp_dir_cleaner() # destroy temp dir
 
-    def call_command(self, *args, **kwargs):
-        stdout = StringIO()
-        try:
-            kwargs['stdout'] = stdout
-            call_command(*args, **kwargs)
-        except SystemExit as err:
-            return err.code, stdout.getvalue()
-        self.fail("ingest script should always throw a systemexit()")
-
     def test_single_ingest_from_cli(self):
         "ensure an ingest from the cli can happen targeting a specific file"
         args = [self.nom, '--target', self.ajson_fixture]
-        errcode, stdout = self.call_command(*args)
+        errcode, stdout = call_command(*args)
         self.assertEqual(errcode, 0)
         # article has been ingested
         self.assertEqual(models.Article.objects.count(), 1)
@@ -36,7 +25,7 @@ class Cmd(BaseCase):
     def test_many_ingest_from_cli(self):
         "ensure an ingest from the cli can happen targeting a directory of files"
         args = [self.nom, '--target', join(self.fixture_dir, 'ajson')]
-        errcode, stdout = self.call_command(*args)
+        errcode, stdout = call_command(*args)
         self.assertEqual(errcode, 0)
         # all articles have been ingested
         self.assertEqual(models.Article.objects.count(), self.num_unique_articles)
@@ -45,7 +34,7 @@ class Cmd(BaseCase):
         "ensure command fails with exit status 1 on bad data"
         self.assertEqual(models.Article.objects.count(), 0)
         args = [self.nom, '--target', '/dev/null']
-        errcode, stdout = self.call_command(*args)
+        errcode, stdout = call_command(*args)
         self.assertEqual(errcode, 1)
         self.assertEqual(models.Article.objects.count(), 0)
 
@@ -59,6 +48,6 @@ class Cmd(BaseCase):
         self.assertTrue(os.path.exists(tempfile_path))
 
         args = [self.nom, '--target', tempfile_path]
-        errcode, stdout = self.call_command(*args)
+        errcode, stdout = call_command(*args)
         self.assertEqual(errcode, 1)
         self.assertEqual(models.Article.objects.count(), 0)

--- a/src/observer/tests/test_cmd_regen.py
+++ b/src/observer/tests/test_cmd_regen.py
@@ -1,0 +1,32 @@
+from os.path import join
+from .base import BaseCase, call_command
+from observer import models, ingest_logic as logic
+
+class Cmd(BaseCase):
+    def setUp(self):
+        self.nom = 'regen'
+
+    def tearDown(self):
+        pass
+
+    def test_regen_no_articles(self):
+        args = [self.nom]
+        errcode, stdout = call_command(*args)
+        self.assertEqual(errcode, 0)
+
+    def test_regen_some_articles(self):
+        self.article_json = join(self.fixture_dir, 'ajson', 'elife-13964-v1.xml.json')
+
+        # load the ArticleJSON in
+        logic.file_upsert(self.article_json, regen=False)
+
+        # ensure no articles exist yet
+        self.assertEqual(models.Article.objects.count(), 0)
+
+        args = [self.nom]
+        errcode, stdout = call_command(*args)
+
+        self.assertEqual(errcode, 0)
+
+        # article has been ingested
+        self.assertEqual(models.Article.objects.count(), 1)

--- a/src/observer/tests/test_csv_views.py
+++ b/src/observer/tests/test_csv_views.py
@@ -6,10 +6,30 @@ from os.path import join
 from .base import BaseCase
 from django.test import Client
 from django.core.urlresolvers import reverse
-from observer import ingest_logic  # , models
+from observer import ingest_logic, csv, reports
 from observer.utils import listfiles
 
-class One(BaseCase):
+#
+# todo: consider removing this whole file. it's pretty much covered now in test_views.py
+#
+
+class Int(BaseCase):
+    def setUp(self):
+        for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
+            ingest_logic.file_upsert(path)
+        ingest_logic.regenerate_all()
+
+    def test_a_csv_report(self):
+        "a report that is known to support csv rendering can do so outside of http request/response"
+        report, context = reports.published_research_article_index(), {}
+        # result is actually a StreamingHttpResponse, but can be traversed like an iterator
+        result = csv.format_report(report, context)
+        for row in result:
+            bits = row.decode('utf8').split(',')
+            self.assertEqual(len(bits), 3)
+            int(bits[0])
+
+class Ext(BaseCase):
     def setUp(self):
         self.c = Client()
         for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
@@ -20,6 +40,7 @@ class One(BaseCase):
         pass
 
     def test_csv_report(self):
+        "a report that is known to support csv rendering can do so within a http request/response"
         url = reverse('report', kwargs={'name': 'published-research-article-index'})
         resp = self.c.get(url)
         self.assertEqual(resp.status_code, 200)

--- a/src/observer/tests/test_ingest_logic.py
+++ b/src/observer/tests/test_ingest_logic.py
@@ -5,7 +5,7 @@ from observer import ingest_logic as logic, models, utils
 
 class Logic(BaseCase):
     def setUp(self):
-        self.unique_article_count = 4
+        self.unique_article_count = 5
         self.article_json = join(self.fixture_dir, 'ajson', 'elife-13964-v1.xml.json')
 
     def test_flatten(self):

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -65,7 +65,7 @@ class Two(BaseCase):
         pass
 
     def test_report_paginated(self):
-        expected_articles = 4 # 4 articles, 11 article versions
+        expected_articles = 5 # 5 articles, 12 article versions
         self.assertEqual(models.Article.objects.count(), expected_articles)
 
         url = reverse('report', kwargs={'name': 'latest-articles'})

--- a/src/observer/tests/test_views.py
+++ b/src/observer/tests/test_views.py
@@ -63,6 +63,14 @@ class Three(BaseCase):
         resp = self.c.get("/")
         self.assertEqual(resp.status_code, 200)
 
+    def test_slashes_not_appended(self):
+        "ensure a slash is not appended to the end of a url"
+        url = reverse('report', kwargs={'name': 'latest-articles'})
+        self.assertFalse(url.endswith('/'))
+        # ensure we go directly to the url without redirecting to a slash suffixed one
+        resp = self.c.get(url, follow=False)
+        self.assertEqual(resp.status_code, 200)
+
 class Four(BaseCase):
     def setUp(self):
         self.c = Client()

--- a/src/observer/tests/test_views.py
+++ b/src/observer/tests/test_views.py
@@ -12,8 +12,26 @@ class One(BaseCase):
         self.assertEqual(resp.status_code, 200)
 
     def test_reports(self):
-        "ensure all of the known reports can be hit with a successful response"
+        "all known reports can be hit with a successful response"
         known_reports = reports.known_report_idx().keys()
         for name in known_reports:
             url = reverse('report', kwargs={'name': name})
-            self.assertEqual(self.c.get(url).status_code, 200, "report at %r returned non-200 response" % url)
+            resp = self.c.get(url)
+            self.assertEqual(resp.status_code, 200, "report at %r returned non-200 response" % url)
+
+    def test_report_format_hint(self):
+        "providing a file extension to a report name is the same as providing ?format=foo"
+
+        # default serialization for this particular report is RSS
+        self.assertEqual(reports.latest_articles.meta[reports.SERIALISATIONS][0], reports.RSS)
+        
+        # and here we hint we're after .json
+        url = reverse('report', kwargs={'name': 'latest-articles'})
+        url += ".json"
+        resp = self.c.get(url)
+        # the hint is understood
+        self.assertEqual(resp.status_code, 200)
+
+    def test_report_format_param_overrides_format_hint(self):
+        "the format parameter wins when providing both a file extension format hint and a format param"
+        pass

--- a/src/observer/tests/test_views.py
+++ b/src/observer/tests/test_views.py
@@ -1,9 +1,61 @@
+from os.path import join
 from django.test import Client
 from .base import BaseCase
-from observer import reports
+from observer import reports, ingest_logic, models
 from django.core.urlresolvers import reverse
+from observer.utils import listfiles, lmap
+
+class Zero(BaseCase):
+    def test_reports_no_data(self):
+        "an unpopulated observer instance doesn't break when empty"
+        self.assertEqual(models.Article.objects.count(), 0)
+        for report_name, reportfn in reports.known_report_idx().items():
+            report = reportfn()
+            for format in report['serialisations']:
+                context = {}
+                resp = reports.format_report(report, format, context)
+                # realize any results
+                if resp.streaming:
+                    lmap(str, resp.streaming_content)
+                else:
+                    str(resp.content)
 
 class One(BaseCase):
+    def setUp(self):
+        self.c = Client()
+        for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
+            ingest_logic.file_upsert(path)
+        ingest_logic.regenerate_all()
+
+    def test_reports(self):
+        "all known reports can be formatted with results"
+        for report_name, reportfn in reports.known_report_idx().items():
+            report = reportfn()
+            for format in report['serialisations']:
+                context = {}
+                resp = reports.format_report(report, format, context)
+                # realize any results
+                if resp.streaming:
+                    lmap(str, resp.streaming_content)
+                else:
+                    str(resp.content)
+
+class Two(BaseCase):
+    def setUp(self):
+        self.c = Client()
+        for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
+            ingest_logic.file_upsert(path)
+        ingest_logic.regenerate_all()
+
+    def test_reports(self):
+        "all known reports in all support formats can be hit with a successful response"
+        for report_name, reportfn in reports.known_report_idx().items():
+            url = reverse('report', kwargs={'name': report_name})
+            for format in reportfn.meta['serialisations']:
+                resp = self.c.get(url, {'format': format})
+                self.assertEqual(resp.status_code, 200, "report at %r returned non-200 response" % url)
+
+class Three(BaseCase):
     def setUp(self):
         self.c = Client()
 
@@ -11,26 +63,31 @@ class One(BaseCase):
         resp = self.c.get("/")
         self.assertEqual(resp.status_code, 200)
 
-    def test_reports(self):
-        "all known reports can be hit with a successful response"
-        known_reports = reports.known_report_idx().keys()
-        for name in known_reports:
-            url = reverse('report', kwargs={'name': name})
-            resp = self.c.get(url)
-            self.assertEqual(resp.status_code, 200, "report at %r returned non-200 response" % url)
+class Four(BaseCase):
+    def setUp(self):
+        self.c = Client()
+        for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
+            ingest_logic.file_upsert(path)
+        ingest_logic.regenerate_all()
 
     def test_report_format_hint(self):
         "providing a file extension to a report name is the same as providing ?format=foo"
 
-        # default serialization for this particular report is RSS
-        self.assertEqual(reports.latest_articles.meta[reports.SERIALISATIONS][0], reports.RSS)
-        
-        # and here we hint we're after .json
-        url = reverse('report', kwargs={'name': 'latest-articles'})
-        url += ".json"
-        resp = self.c.get(url)
-        # the hint is understood
-        self.assertEqual(resp.status_code, 200)
+        for report_name, reportfn in reports.known_report_idx().items():
+            url = reverse('report', kwargs={'name': report_name})
+            for format in reportfn.meta['serialisations']:
+                furl = url + ".%s" % format.lower()
+                resp = self.c.get(furl)  # , {'format': format}) # no explicit param is provided
+                self.assertEqual(resp.status_code, 200, "report at %r returned non-200 response" % url)
+
+                # test the content
+                if format == reports.CSV:
+                    # it's a list of strings with commas in it.
+                    list(resp.streaming_content)[0].decode('utf8').split(',')[0]
+                elif format == reports.RSS:
+                    # it's an xml doc
+                    prefix = "<?xml version='1.0' encoding='UTF-8'?>"
+                    resp.content.decode('utf8').startswith(prefix)
 
     def test_report_format_param_overrides_format_hint(self):
         "the format parameter wins when providing both a file extension format hint and a format param"

--- a/src/observer/urls.py
+++ b/src/observer/urls.py
@@ -3,5 +3,6 @@ from . import views
 
 urlpatterns = [
     url('^report/(?P<name>[\-\w]+)$', views.report, name='report'),
+    url('^report/(?P<name>[\-\w]+)\.(?P<format_hint>[\w]{1,4})$', views.report, name='report'),
     url(r'^$', views.landing, name='pub-landing'),
 ]

--- a/src/observer/urls.py
+++ b/src/observer/urls.py
@@ -2,6 +2,6 @@ from django.conf.urls import url
 from . import views
 
 urlpatterns = [
-    url('^report/(?P<name>[\-\w]+)/$', views.report, name='report'),
+    url('^report/(?P<name>[\-\w]+)$', views.report, name='report'),
     url(r'^$', views.landing, name='pub-landing'),
 ]

--- a/src/observer/utils.py
+++ b/src/observer/utils.py
@@ -21,7 +21,7 @@ def nth(x, n):
 
 first = partial(nth, n=0)
 second = partial(nth, n=1)
-    
+
 def ensure(assertion, msg, *args):
     """intended as a convenient replacement for `assert` statements that
     get compiled away with -O flags"""

--- a/src/observer/utils.py
+++ b/src/observer/utils.py
@@ -1,3 +1,4 @@
+from functools import partial
 from rfc3339 import rfc3339
 import os
 from os.path import join
@@ -12,12 +13,15 @@ import shutil
 
 LOG = logging.getLogger(__name__)
 
-def first(x):
+def nth(x, n):
     try:
-        return x[0]
+        return x[n]
     except IndexError:
         return None
 
+first = partial(nth, n=0)
+second = partial(nth, n=1)
+    
 def ensure(assertion, msg, *args):
     """intended as a convenient replacement for `assert` statements that
     get compiled away with -O flags"""
@@ -51,6 +55,12 @@ def isint(v):
 
 lmap = lambda func, *iterable: list(map(func, *iterable))
 lfilter = lambda func, *iterable: list(filter(func, *iterable))
+
+def val_map(fn, d):
+    return {k: fn(v) for k, v in d.items()}
+
+def key_map(fn, d):
+    return {fn(k): v for k, v in d.items()}
 
 def todt(val):
     "turn almost any formatted datetime string into a UTC datetime object"

--- a/src/observer/views.py
+++ b/src/observer/views.py
@@ -8,10 +8,10 @@ from et3.extract import path as p
 from et3.utils import uppercase
 from annoying.decorators import render_to
 from .utils import ensure, isint
-from . import reports, rss, csv
+from . import reports
 import logging
 
-from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY, RSS, CSV
+from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY
 
 LOG = logging.getLogger(__name__)
 
@@ -88,15 +88,6 @@ def paginate_report_results(report, rargs):
 
     return report
 
-def format_report(report, rargs, context):
-    # the report has been executed at this point
-    known_formats = {
-        RSS: rss.format_report,
-        CSV: csv.format_report,
-    }
-    return known_formats[report['format']](report, context)
-
-
 #
 # views
 #
@@ -133,7 +124,7 @@ def report(request, name, format_hint=None):
         context = {
             'link': "https://observer.elifesciences.org" + reverse('report', kwargs={'name': name}),
         }
-        return format_report(report_paginated, rargs, context)
+        return reports.format_report(report_paginated, rargs['format'], context)
 
     except BaseException:
         LOG.exception("unhandled exception")

--- a/src/observer/views.py
+++ b/src/observer/views.py
@@ -12,7 +12,8 @@ from .utils import ensure, isint
 from . import reports
 import logging
 
-from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY
+from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY, RSS, CSV
+from observer import rss, csv
 
 LOG = logging.getLogger(__name__)
 

--- a/src/observer/views.py
+++ b/src/observer/views.py
@@ -1,4 +1,3 @@
-import copy
 from os.path import join
 from django.core.urlresolvers import reverse
 from django.http import HttpResponse
@@ -12,8 +11,7 @@ from .utils import ensure, isint
 from . import reports
 import logging
 
-from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY, RSS, CSV
-from observer import rss, csv
+from .reports import PER_PAGE, ORDER, SERIALISATIONS, NO_PAGINATION, ORDER_BY
 
 LOG = logging.getLogger(__name__)
 
@@ -89,16 +87,6 @@ def paginate_report_results(report, rargs):
     report.update(rargs)
 
     return report
-
-def format_report(report, rargs, context):
-    # the report has been executed at this point
-    known_formats = {
-        RSS: rss.format_report,
-        CSV: csv.format_report,
-    }
-    report = copy.deepcopy(report)
-    return known_formats[report['format']](report, context)
-
 
 #
 # views


### PR DESCRIPTION
reports can be access at `/report/report-name` and that will give you the default serialisation for that report, but if you want the report in other common formats and you can't be bothered (or more likely, don't know how) passing the `?format=foo` parameter, you can now go:

    /report/report-name.ext

*magic!* so, 

    /report/latest-articles.csv
    /report/latest-articles.rss
    /report/latest-articles.json (when I support json)

but more importantly:

    /report/published-research-article-index.csv

(formally `published.csv`, the same published.csv that everybody is still hand editing )