### PR TITLE
Installing pinned version of New Relic Python module

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,6 +9,7 @@ green==2.5.0
 rfc3339==5.2
 ipython==5.1.0
 kids.cache==0.0.4
+newrelic==2.78.0.57
 psycopg2==2.7.1
 pyflakes==1.3.0
 pylint==1.6.4


### PR DESCRIPTION
If I write `pip freeze` into `requirements.txt` I get many more packages, which means the current build is non-repeatable. However, cannot change this now nor sure whether to do it