### PR TITLE
New Relic in background process transactions

### DIFF
--- a/src/observer/management/commands/article_update_listener.py
+++ b/src/observer/management/commands/article_update_listener.py
@@ -30,6 +30,13 @@ class Command(BaseCommand):
                     LOG.exception("unhandled exception attempting to download and regenerate article %s", msid)
 
             LOG.info("attempting connection %s ...", settings.ARTICLE_EVENT_QUEUE)
+
+            try:
+                import newrelic.agent
+                action = newrelic.agent.background_task()(action)
+            except ImportError:
+                pass
+
             lmap(action, inc.poll(inc.queue(settings.ARTICLE_EVENT_QUEUE)))
 
         except ValueError as err:


### PR DESCRIPTION
New Relic detects the Django HTTP requests by itself, but we may need this to decorate the background process. We may not actually need it if it is automatically picked up.