### PR TITLE
feature: fewer queries 

### DIFF
--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -49,8 +49,9 @@ def latest_articles():
     * returns -all- articles
     * ordered by the date the first version was published, most recent to least recent
     """
-    return models.Article.objects.prefetch_related('subjects', 'authors').all().order_by('-datetime_published')
-
+    return models.Article.objects \
+        .all() \
+        .order_by('-datetime_published')
 
 @report(article_meta(
     title='upcoming articles',

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -49,9 +49,7 @@ def latest_articles():
     * returns -all- articles
     * ordered by the date the first version was published, most recent to least recent
     """
-    return models.Article.objects \
-        .all() \
-        .order_by('-datetime_published')
+    return models.Article.objects.all().order_by('-datetime_published')
 
 @report(article_meta(
     title='upcoming articles',
@@ -99,7 +97,7 @@ def format_report(report, format, context):
         RSS: rss.format_report,
         CSV: csv.format_report,
     }
-    ensure(format in report[SERIALISATIONS], "unsupported format %r for report %s" % (format, report))
+    ensure(format in report[SERIALISATIONS], "unsupported format %r for report %s" % (format, report['title']))
     report = copy.deepcopy(report)
     return known_formats[format](report, context)
 

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -49,7 +49,7 @@ def latest_articles():
     * returns -all- articles
     * ordered by the date the first version was published, most recent to least recent
     """
-    return models.Article.objects.all().order_by('-datetime_published')
+    return models.Article.objects.prefetch_related('subjects', 'authors').all().order_by('-datetime_published')
 
 
 @report(article_meta(

--- a/src/observer/rss.py
+++ b/src/observer/rss.py
@@ -87,7 +87,9 @@ def format_report(report, context):
     report.update(context) # yes, this nukes any conflicting keys in the report
     report['title'] = 'eLife: ' + report['title']
     feed = mkfeed(report)
-    add_many_entries(feed, map(article_to_rss_entry, report['items'])) # deliberate use of lazy map
+    query = report['items']
+    query = query.prefetch_related('subjects', 'authors')
+    add_many_entries(feed, map(article_to_rss_entry, query)) # deliberate use of lazy map
     body = feed.rss_str(pretty=True).decode('utf-8')
     return HttpResponse(body, content_type='text/xml')
 

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -113,6 +113,11 @@ class Two(BaseCase):
 
     def test_report_keeps_query_count_low(self):
         # worse case is 23 without prefetching
-        magic_num = 17 # after django fanciness
+        magic_num = 15 # after django fanciness
         with self.assertNumQueries(magic_num):
             self.c.get(reverse('report', kwargs={'name': 'latest-articles'}))
+
+        # worse case is 9 without prefetching
+        magic_num = 7
+        with self.assertNumQueries(magic_num):
+            self.c.get(reverse('report', kwargs={'name': 'upcoming-articles'}))

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -82,6 +82,7 @@ class Two(BaseCase):
         "ensure report is ordered correctly"
         url = reverse('report', kwargs={'name': 'latest-articles'})
         resp = self.c.get(url)
+        self.assertEqual(resp.status_code, 200)
         xml = resp.content.decode('utf-8')
 
         regex = r"<dc:date>(.+)</dc:date>"
@@ -109,3 +110,9 @@ class Two(BaseCase):
         def rdf(d1, d2):
             return d1 if d1 >= d2 else d2
         self.assertEqual(reduce(rdf, date_list), date_list[-1])
+
+    def test_report_keeps_query_count_low(self):
+        # worse case is 23 without prefetching
+        magic_num = 17 # after django fanciness
+        with self.assertNumQueries(magic_num):
+            self.c.get(reverse('report', kwargs={'name': 'latest-articles'}))

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -112,12 +112,21 @@ class Two(BaseCase):
         self.assertEqual(reduce(rdf, date_list), date_list[-1])
 
     def test_report_keeps_query_count_low(self):
-        # worse case is 23 without prefetching
-        magic_num = 15 # after django fanciness
+        # worse case here is 12 without prefetching
+        magic_num = 4 # after django fanciness
         with self.assertNumQueries(magic_num):
             self.c.get(reverse('report', kwargs={'name': 'latest-articles'}))
 
-        # worse case is 9 without prefetching
-        magic_num = 7
+        # worse case is also 4 without prefetching
+        magic_num = 4
         with self.assertNumQueries(magic_num):
             self.c.get(reverse('report', kwargs={'name': 'upcoming-articles'}))
+
+        # with a simple csv report that doesn't descend into many-to-many fields, we can whittle a
+        # request down to just 3 requests
+        paginate = 1
+        csv_peek = 1
+        csv_generation = 1
+        num = paginate + csv_peek + csv_generation
+        with self.assertNumQueries(num):
+            self.c.get(reverse('report', kwargs={'name': 'latest-articles'}), {'format': 'csv'})

--- a/src/observer/utils.py
+++ b/src/observer/utils.py
@@ -135,12 +135,12 @@ def deepmerge(a, b, path=None):
     return _merge(a, b, path)
 
 
-def to_dict(instance):
+def to_dict(instance, descend_into_mn_fields=False):
     from django.db.models.fields.related import ManyToManyField
     opts = instance._meta
     data = {}
     for f in opts.concrete_fields + opts.many_to_many:
-        if isinstance(f, ManyToManyField):
+        if isinstance(f, ManyToManyField) and descend_into_mn_fields:
             if instance.pk is None:
                 data[f.name] = []
             else:


### PR DESCRIPTION
* the rss report now prefetches relations resulting in a few less queries.
* many-to-many relations are no longer queried when dumping a row to a dictionary unless explicitly told to do so.
* any operation that involved printing/interpolating a django queryset object has been removed - these evaluate the query

the changes reduce the number of queries from 23 to 4 for the latest-articles rss report using test fixtures and 9 to 4 for upcoming articles.

a regular csv report of the latest articles has gone from 7 to 3 queries