### PR TITLE
ELPP-3356 Avoid child process in manage.sh

### DIFF
--- a/manage.sh
+++ b/manage.sh
@@ -3,4 +3,4 @@
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
 cd $DIR
 source install.sh > /dev/null
-./src/manage.py $@
+exec ./src/manage.py $@


### PR DESCRIPTION
Avoids this situation when using manage.sh for the long-running process:
```
 747 ?        Ss     0:00 /bin/bash ./manage.sh article_update_listener
1485 ?        S      0:00  \_ python ./src/manage.py article_update_listener
```