### PR TITLE
moved consume into module that includes exponential backoff and caching

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 autopep8==1.2.4
+backoff==1.4.3
 boto3==1.4.4
 coverage==4.1
 Django==1.11

--- a/src/observer/consume.py
+++ b/src/observer/consume.py
@@ -1,0 +1,49 @@
+import backoff, requests, requests_cache
+from datetime import timedelta
+from django.conf import settings
+import logging
+
+LOG = logging.getLogger(__name__)
+
+logging.getLogger('backoff').setLevel(logging.CRITICAL)
+
+if settings.DEBUG:
+    requests_cache.install_cache(**{
+        'cache_name': '/tmp/api-cache',
+        'backend': 'sqlite',
+        'fast_save': True,
+        'extension': '.sqlite3',
+        # https://requests-cache.readthedocs.io/en/latest/user_guide.html#expiration
+        'expire_after': timedelta(hours=24)
+    })
+
+def _giving_up(details):
+    LOG.error("request %s failed after %s attempts", details['args'][0], details['tries'])
+
+def _retrying(details):
+    LOG.warn("re-attempting request: %s", details['args'][0])
+
+@backoff.on_exception(
+    backoff.expo,
+    requests.exceptions.RequestException,
+    max_tries=5,
+    on_backoff=_retrying,
+    on_giveup=_giving_up)
+def requests_get(*args, **kwargs):
+    "requests.get wrapper that handles attempts to re-try a request on error EXCEPT on 404 responses"
+    try:
+        resp = requests.get(*args, **kwargs)
+        resp.raise_for_status()
+        return resp
+    except requests.exceptions.RequestException as err:
+        if err.response.status_code == 404:
+            LOG.warn("object at %s not found, not re-attempting request", args[0])
+        else:
+            raise # caught by backoff
+
+def consume(endpoint, usrparams={}):
+    params = {'per-page': 100, 'page': 1}
+    params.update(usrparams)
+    url = settings.API_URL + "/" + endpoint.strip('/')
+    LOG.info('fetching %s params %s' % (url, params))
+    return requests_get(url, params).json()

--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -1,16 +1,13 @@
 import os, math, json
 from functools import partial
 from django.db import transaction
-import requests
-from django.conf import settings
-import requests_cache
-from datetime import timedelta
 from et3 import render
 from et3.extract import path as p
 from . import utils, models, logic
 from .utils import lmap, lfilter, create_or_update, delall, first, second, third
 #from kids.cache import cache
 import logging
+from .consume import consume
 
 LOG = logging.getLogger(__name__)
 
@@ -380,25 +377,6 @@ def regenerate_all():
 #
 # upsert article-json from api
 #
-
-if settings.DEBUG:
-    requests_cache.install_cache(**{
-        'cache_name': '/tmp/api-cache',
-        'backend': 'sqlite',
-        'fast_save': True,
-        'extension': '.sqlite3',
-        # https://requests-cache.readthedocs.io/en/latest/user_guide.html#expiration
-        'expire_after': timedelta(hours=24)
-    })
-
-def consume(endpoint, usrparams={}):
-    params = {'per-page': 100, 'page': 1}
-    params.update(usrparams)
-    url = settings.API_URL + "/" + endpoint.strip('/')
-    LOG.info('fetching %s params %s' % (url, params))
-    resp = requests.get(url, params)
-    resp.raise_for_status()
-    return resp.json()
 
 def mkidx():
     "downloads *all* article snippets to create an msid:version index"

--- a/src/observer/management/commands/article_update_listener.py
+++ b/src/observer/management/commands/article_update_listener.py
@@ -1,5 +1,4 @@
 import sys, json
-import requests
 from django.conf import settings
 from django.core.management.base import BaseCommand
 import logging
@@ -22,10 +21,6 @@ class Command(BaseCommand):
                     msid = json.loads(event)['id']
                     ingest_logic.download_article_versions(msid)
                     ingest_logic.regenerate(msid)
-
-                except requests.exceptions.RequestException as err:
-                    log = LOG.warn if err.response.status_code == 404 else LOG.error
-                    log("failed to fetch article %s: %s", msid, err)
 
                 except BaseException as err:
                     LOG.exception("unhandled exception attempting to download and regenerate article %s", msid)


### PR DESCRIPTION
handles Kong `503` errors of which observer got a tonne this morning/evening:

```json
{
  "asctime": "2018-01-18 02:31:40,724",
  "created": 1516242700.724998,
  "levelname": "ERROR",
  "message": "failed to fetch article 23471: 503 Server Error: Service Unavailable: Back-end server is at capacity for url: https://prod--gateway.elifesciences.org/articles/23471/versions?per-page\u003d100\u0026page\u003d1",
  "filename": "article_update_listener.py",
  "funcName": "action",
  "lineno": 28,
  "module": "article_update_listener",
  "pathname": "/srv/observer/src/observer/management/commands/article_update_listener.py"
}
{
  "asctime": "2018-01-18 02:31:41,155",
  "created": 1516242701.1555045,
  "levelname": "ERROR",
  "message": "failed to fetch article 21522: 503 Server Error: Service Unavailable: Back-end server is at capacity for url: https://prod--gateway.elifesciences.org/articles/21522/versions?per-page\u003d100\u0026page\u003d1",
  "filename": "article_update_listener.py",
  "funcName": "action",
  "lineno": 28,
  "module": "article_update_listener",
  "pathname": "/srv/observer/src/observer/management/commands/article_update_listener.py"
}
{
  "asctime": "2018-01-18 02:31:41,196",
  "created": 1516242701.1968682,
  "levelname": "ERROR",
  "message": "failed to fetch article 21510: 503 Server Error: Service Unavailable: Back-end server is at capacity for url: https://prod--gateway.elifesciences.org/articles/21510/versions?per-page\u003d100\u0026page\u003d1",
  "filename": "article_update_listener.py",
  "funcName": "action",
  "lineno": 28,
  "module": "article_update_listener",
  "pathname": "/srv/observer/src/observer/management/commands/article_update_listener.py"
}
```