### PR TITLE
tweaked the backoff decorator so even 404 errors are not swallowed

### DIFF
--- a/src/observer/management/commands/article_update_listener.py
+++ b/src/observer/management/commands/article_update_listener.py
@@ -4,6 +4,7 @@ from django.core.management.base import BaseCommand
 import logging
 from observer import inc, ingest_logic
 from observer.utils import lmap
+import requests
 
 LOG = logging.getLogger(__name__)
 
@@ -21,6 +22,10 @@ class Command(BaseCommand):
                     msid = json.loads(event)['id']
                     ingest_logic.download_article_versions(msid)
                     ingest_logic.regenerate(msid)
+
+                except requests.exceptions.RequestException as err:
+                    log = LOG.warn if err.response.status_code == 404 else LOG.error
+                    log("failed to fetch article %s: %s", msid, err)
 
                 except BaseException as err:
                     LOG.exception("unhandled exception attempting to download and regenerate article %s", msid)


### PR DESCRIPTION
it means calling code still needs to handle cases http errors, they just have backoff giving it a few more attempts before failing