### PR TITLE
added ability to specify targets to load_from_api command

### DIFF
--- a/src/observer/management/commands/load_from_api.py
+++ b/src/observer/management/commands/load_from_api.py
@@ -12,7 +12,7 @@ from functools import partial
 LAX, METRICS = TARGETS = ['lax', 'elife-metrics']
 
 class Command(BaseCommand):
-    help = "a terrifically sequential and SLOW way to load ALL elife articles and versions"
+    help = "loads ALL elife articles and versions and metrics summary"
 
     def add_arguments(self, parser):
         parser.add_argument('--msid', nargs='+', type=int, required=False)
@@ -35,7 +35,8 @@ class Command(BaseCommand):
                 (METRICS, dl_metrics),
             ])
 
-            fnlist = (subdict(targets, options['target']) or targets).values()
+            targetlist = options['target'] or []
+            fnlist = (subdict(targets, targetlist) or targets).values()
             [fn() for fn in fnlist]
 
             regen()

--- a/src/observer/tests/base.py
+++ b/src/observer/tests/base.py
@@ -1,3 +1,4 @@
+import json
 import os
 from django.test import TestCase
 from io import StringIO
@@ -18,3 +19,8 @@ class BaseCase(TestCase):
 
     def freshen(self, obj):
         return type(obj).objects.get(pk=obj.pk)
+
+    def jsonfix(self, *bits):
+        bits = [self.fixture_dir] + list(bits)
+        path = os.path.join(*bits)
+        return json.load(open(path, 'r'))

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -51,3 +51,11 @@ class Cmd(BaseCase):
         errcode, stdout = call_command(*args)
         self.assertEqual(errcode, 1)
         self.assertEqual(models.Article.objects.count(), 0)
+
+    def test_ingest_selective_msids(self):
+        "specific articles can be ingested"
+        self.fail()
+
+    def test_ingest_selective_targets(self):
+        "specific targets (lax, elife-metrics) can be specified"
+        self.fail()

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -1,10 +1,11 @@
+from unittest.mock import patch
 import os
 from os.path import join
 import json
 from .base import BaseCase, call_command
 from observer import models, utils
 
-class Cmd(BaseCase):
+class LoadFromFS(BaseCase):
     def setUp(self):
         self.nom = 'load_from_fs'
         self.ajson_fixture = join(self.fixture_dir, 'ajson', 'elife-13964-v1.xml.json')
@@ -52,10 +53,60 @@ class Cmd(BaseCase):
         self.assertEqual(errcode, 1)
         self.assertEqual(models.Article.objects.count(), 0)
 
+'''
+# beware: patch with 'new' behaves *very* strangely and cannot be trusted
+# I think the underlying cause is that `call_command` is executing the management
+# command outside of this process, bypassing any patching.
+class LoadFromAPI(BaseCase):
+    def setUp(self):
+        self.nom = 'load_from_api'
+        self.temp_dir, self.temp_dir_cleaner = utils.tempdir()
+
+    def tearDown(self):
+        self.temp_dir_cleaner() # destroy temp dir
+
     def test_ingest_selective_msids(self):
         "specific articles can be ingested"
-        self.fail()
+        args = [self.nom, '--msid', "13964"]
+
+        def dispatch(endpoint, args={}):
+            # call to determine max version
+            if endpoint.startswith('articles') and endpoint.endswith('versions'):
+                return self.jsonfix('ajson-versions', '13964.json')
+            # call to fetch article data
+            elif endpoint.startswith('articles'):
+                # will return the v1 three times :(
+                return self.jsonfix('ajson', 'elife-13964-v1.xml.json')
+            # call to fetch metrics data
+            elif endpoint.startswith('metrics'):
+                return self.jsonfix('metrics-summary', 'single.json')
+            raise AssertionError("unknown call")
+
+        with patch('observer.consume.consume', new=dispatch):
+            errcode, stdout = call_command(*args)
+            self.assertEqual(errcode, 0)
+            self.assertEqual(models.Article.objects.count(), 1)
+            self.assertEqual(models.ArticleJSON.objects.count(), 4) # ajson versions 1-3 + metrics json
+
+
+    def dispatcher(self, endpoint, args=None):
+        # call to fetch metrics data
+        if endpoint.startswith('metrics'):
+            x = self.jsonfix('metrics-summary', 'many.json')
+            print("got", x)
+            return x
+        raise AssertionError("unknown call")
 
     def test_ingest_selective_targets(self):
         "specific targets (lax, elife-metrics) can be specified"
-        self.fail()
+        args = [self.nom, '--target', "elife-metrics"]
+
+        self.assertEqual(models.Article.objects.count(), 0)
+        self.assertEqual(models.ArticleJSON.objects.count(), 0)
+
+        with patch('observer.consume.consume', new=self.dispatcher):
+            errcode, stdout = call_command(*args)
+            self.assertEqual(errcode, 0)
+            #print(">>>",[x.ajson for x in models.ArticleJSON.objects.all()])
+            self.assertEqual(models.ArticleJSON.objects.count(), 100)
+'''

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -1,4 +1,3 @@
-from unittest.mock import patch
 import os
 from os.path import join
 import json


### PR DESCRIPTION
this means we can now re-fetch metrics for all or specific articles