### PR TITLE
adds cache control middleware

### DIFF
--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -1,4 +1,3 @@
-from django.conf import settings
 from django.views.decorators.cache import patch_cache_control
 from django.utils.cache import patch_vary_headers
 
@@ -7,7 +6,7 @@ class DownstreamCaching(object):
         self.get_response = get_response
 
     def __call__(self, request):
-        public_headers = {
+        headers = {
             'public': True,
 
             # could probably bump these values to 10minutes.
@@ -16,16 +15,6 @@ class DownstreamCaching(object):
             'stale-while-revalidate': 60 * 5, # 5 minutes, 300 seconds
             'stale-if-error': (60 * 60) * 24, # 1 day, 86400 seconds
         }
-        private_headers = {
-            'private': True,
-            'max-age': 0, # seconds
-            'must-revalidate': True,
-        }
-
-        # nothing currently sets the authenticated header or not
-        authenticated = request.META.get(settings.KONG_AUTH_HEADER)
-        headers = public_headers if not authenticated else private_headers
-
         response = self.get_response(request)
 
         if not response.get('Cache-Control'):

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -11,7 +11,7 @@ class DownstreamCaching(object):
             'public': True,
 
             # could probably bump these values to 10minutes.
-            
+
             'max-age': 60 * 5, # 5 minutes, 300 seconds
             'stale-while-revalidate': 60 * 5, # 5 minutes, 300 seconds
             'stale-if-error': (60 * 60) * 24, # 1 day, 86400 seconds
@@ -23,7 +23,7 @@ class DownstreamCaching(object):
         }
 
         # nothing currently sets the authenticated header or not
-        authenticated = request.META.get(settings.KONG_AUTH_HEADER) 
+        authenticated = request.META.get(settings.KONG_AUTH_HEADER)
         headers = public_headers if not authenticated else private_headers
 
         response = self.get_response(request)

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -1,0 +1,35 @@
+from django.conf import settings
+from django.views.decorators.cache import patch_cache_control
+from django.utils.cache import patch_vary_headers
+
+class DownstreamCaching(object):
+    def __init__(self, get_response):
+        self.get_response = get_response
+
+    def __call__(self, request):
+        public_headers = {
+            'public': True,
+
+            # could probably bump these values to 10minutes.
+            
+            'max-age': 60 * 5, # 5 minutes, 300 seconds
+            'stale-while-revalidate': 60 * 5, # 5 minutes, 300 seconds
+            'stale-if-error': (60 * 60) * 24, # 1 day, 86400 seconds
+        }
+        private_headers = {
+            'private': True,
+            'max-age': 0, # seconds
+            'must-revalidate': True,
+        }
+
+        # nothing currently sets the authenticated header or not
+        authenticated = request.META.get(settings.KONG_AUTH_HEADER) 
+        headers = public_headers if not authenticated else private_headers
+
+        response = self.get_response(request)
+
+        if not response.get('Cache-Control'):
+            patch_cache_control(response, **headers)
+        patch_vary_headers(response, ['Accept'])
+
+        return response

--- a/src/core/middleware.py
+++ b/src/core/middleware.py
@@ -1,6 +1,9 @@
 from django.views.decorators.cache import patch_cache_control
 from django.utils.cache import patch_vary_headers
 
+MAX_AGE = 60 * 5
+MAX_STALE =  (60 * 60) * 24
+
 class DownstreamCaching(object):
     def __init__(self, get_response):
         self.get_response = get_response
@@ -11,9 +14,9 @@ class DownstreamCaching(object):
 
             # could probably bump these values to 10minutes.
 
-            'max-age': 60 * 5, # 5 minutes, 300 seconds
-            'stale-while-revalidate': 60 * 5, # 5 minutes, 300 seconds
-            'stale-if-error': (60 * 60) * 24, # 1 day, 86400 seconds
+            'max-age': MAX_AGE, # 5 minutes, 300 seconds
+            'stale-while-revalidate': MAX_AGE, # 5 minutes, 300 seconds
+            'stale-if-error': MAX_STALE, # 1 day, 86400 seconds
         }
         response = self.get_response(request)
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -116,8 +116,6 @@ DATABASES = {
 #
 #
 
-KONG_AUTH_HEADER = 'KONG-Authenticated'
-
 API_URL = cfg('general.api-url')
 ARTICLE_EVENT_QUEUE = cfg('sqs.queue-name', None) # ll: observer--ci, observer--prod, observer--2017-04-282
 

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -66,6 +66,8 @@ MIDDLEWARE = [
     'django.contrib.auth.middleware.AuthenticationMiddleware',
     'django.contrib.messages.middleware.MessageMiddleware',
     'django.middleware.clickjacking.XFrameOptionsMiddleware',
+
+    'core.middleware.DownstreamCaching',
 ]
 
 ROOT_URLCONF = 'core.urls'
@@ -113,6 +115,8 @@ DATABASES = {
 #
 #
 #
+
+KONG_AUTH_HEADER = 'KONG-Authenticated'
 
 API_URL = cfg('general.api-url')
 ARTICLE_EVENT_QUEUE = cfg('sqs.queue-name', None) # ll: observer--ci, observer--prod, observer--2017-04-282

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -11,7 +11,7 @@ class DownstreamCaching(TestCase):
 
     def test_cache_headers_in_response(self):
         expected_headers = [
-            'vary',
+            'vary', # redundant
             'etag',
             'cache-control'
         ]

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -1,0 +1,29 @@
+from django.test import TestCase, Client
+
+class DownstreamCaching(TestCase):
+    def setUp(self):
+        self.c = Client()
+        self.url = '/' # we could hit more urls but it's applied application-wide
+
+    def tearDown(self):
+        pass
+
+    def test_cache_headers_in_response(self):
+        expected_headers = [
+            'vary',
+            'etag',
+            'cache-control'
+        ]
+        resp = self.c.get(self.url)
+        for header in expected_headers:
+            self.assertTrue(resp.has_header(header), "header %r not found in response" % header)
+
+    def test_cache_headers_not_in_response(self):
+        cases = [
+            'expires',
+            'last-modified',
+            'prama'
+        ]
+        resp = self.c.get(self.url)
+        for header in cases:
+            self.assertFalse(resp.has_header(header), "header %r present in response" % header)

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -17,12 +17,12 @@ class DownstreamCaching(TestCase):
         resp = self.c.get(self.url)
         for header in expected_headers:
             self.assertTrue(resp.has_header(header), "header %r not found in response" % header)
-
+            
     def test_cache_headers_not_in_response(self):
         cases = [
             'expires',
             'last-modified',
-            'prama'
+            'prama' # HTTP/1.0
         ]
         resp = self.c.get(self.url)
         for header in cases:

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -1,4 +1,5 @@
 from django.test import TestCase, Client
+from core.middleware import MAX_AGE, MAX_STALE
 
 class DownstreamCaching(TestCase):
     def setUp(self):
@@ -17,6 +18,16 @@ class DownstreamCaching(TestCase):
         resp = self.c.get(self.url)
         for header in expected_headers:
             self.assertTrue(resp.has_header(header), "header %r not found in response" % header)
+
+    def test_cache_header_values(self):
+        expected_headers = [
+            ('vary', ['Accept']),
+            ('cache-control', ['max-age=%s' % MAX_AGE, 'public', 'stale-if-error=%s' % MAX_STALE, 'stale-while-revalidate=%s' % MAX_AGE])
+        ]
+        resp = self.c.get(self.url)
+        for header, expected in expected_headers:
+            # dirty parsing to guarantee ordered values
+            self.assertEqual(sorted(resp[header].split(', ')), expected)
 
     def test_cache_headers_not_in_response(self):
         cases = [

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -17,7 +17,7 @@ class DownstreamCaching(TestCase):
         resp = self.c.get(self.url)
         for header in expected_headers:
             self.assertTrue(resp.has_header(header), "header %r not found in response" % header)
-            
+
     def test_cache_headers_not_in_response(self):
         cases = [
             'expires',

--- a/src/observer/tests/test_views.py
+++ b/src/observer/tests/test_views.py
@@ -142,3 +142,14 @@ class Four(BaseCase):
                     # it's an xml doc
                     prefix = "<?xml version='1.0' encoding='UTF-8'?>"
                     resp2.content.decode('utf8').startswith(prefix)
+
+class Five(BaseCase):
+    def setUp(self):
+        self.c = Client()
+
+    def test_ping(self):
+        resp = self.c.get(reverse('ping'))
+        self.assertEqual(resp.status_code, 200)
+        self.assertEqual(resp['content-type'], 'text/plain; charset=UTF-8')
+        self.assertEqual(resp['cache-control'], 'must-revalidate, no-cache, no-store, private')
+        self.assertEqual(resp.content.decode('utf-8'), 'pong')

--- a/src/observer/urls.py
+++ b/src/observer/urls.py
@@ -4,5 +4,6 @@ from . import views
 urlpatterns = [
     url('^report/(?P<name>[\-\w]+)$', views.report, name='report'),
     url('^report/(?P<name>[\-\w]+)\.(?P<format_hint>[\w]{1,4})$', views.report, name='report'),
+    url('^ping$', views.ping, name='ping'),
     url(r'^$', views.landing, name='pub-landing'),
 ]

--- a/src/observer/views.py
+++ b/src/observer/views.py
@@ -94,15 +94,15 @@ def paginate_report_results(report, rargs):
 
     return report
 
-#
-# views
-#
-
 def readme_markdown():
     context = {
         'reports': reports.report_meta(),
     }
     return render_to_string('README.md.template', context)
+
+#
+# views
+#
 
 @render_to("landing.html")
 def landing(request):
@@ -110,6 +110,12 @@ def landing(request):
         'html_title': 'Observer - article reports',
         'readme': readme_markdown()
     }
+
+def ping(request):
+    "returns a test response for monitoring, *never* to be cached"
+    resp = HttpResponse('pong', content_type='text/plain; charset=UTF-8')
+    resp['Cache-Control'] = 'must-revalidate, no-cache, no-store, private'
+    return resp
 
 def report(request, name, format_hint=None):
     try:


### PR DESCRIPTION
copied from lax and tweaked a little.

observer doesn't need to know about authenticated or not yet (ever?), it only uses public data, but it looks like lax is using the authenticated header to serve up uncached results to internal requests. 

for observer I could detect internal requests by looking at the protocol http (internal) vs https (external) or the ip address is in range of internal network ... thoughts?