### PR TITLE
ELPP-3438 Proposal for a safer long-running process script

### DIFF
--- a/headless.sh
+++ b/headless.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# for long-running processes
+set -e
+
+exec venv/bin/python src/manage.py $@


### PR DESCRIPTION
Scripts doesn't touch the virtualenv, nor runs migrations; only starts the mentioned process.

Originally started from seeing tables continuously being recreated by a `article_update_listener` process crashing and being restarted by Upstart.