### PR TITLE
[wip] Feature: improved article regen

### DIFF
--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -175,7 +175,8 @@ DESC = {
     # 'published' doesn't change, ever. it's the v1 pubdate
     'datetime_published': [p('published'), todt],
     # 'versionDate' changes on every single version
-    'datetime_version_published': [p('versionDate'), todt],
+    #'datetime_version_published': [p('versionDate'), todt],
+    'datetime_version_published': [p('published'), todt], # BUG HERE. correct is above
     # poa pubdate is the date the state changed to POA, if any POA present
     'datetime_poa_published': [known_versions(POA), first, _or({}), p('statusDate', EXCLUDE_ME), todt],
     # vor pubdate is the date the state changed to VOR, if any VOR present
@@ -288,7 +289,11 @@ def extract_children(mush):
 def extract_article(msid):
     article_data = models.ArticleJSON.objects.filter(msid=str(msid), ajson_type=models.LAX_AJSON).order_by('version') # ASC
 
+    print('-'*80)
     ensure(article_data.count(), "article %s does not exist" % msid)
+
+    for a in article_data:
+        print(a.msid, a.version)
 
     try:
         metrics_data = models.ArticleJSON.objects.get(msid=str(msid), ajson_type=models.METRICS_SUMMARY).ajson

--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -269,7 +269,8 @@ def extract_article(msid):
     # scrape has access to historical versions too
     article_data = article_version_data[-1]
 
-    LOG.info('extracting %s' % article_data)
+    # TODO: other objects need one of these lines. it's currently just 'committing N objects\ncommiting N objects\n...'
+    LOG.info('extracting %s' % article_data.get('id', '???'))
     article_mush = flatten_article_json(article_data, known_version_list=article_version_data, metrics=metrics_data)
 
     # extract sub-objects from the article data

--- a/src/observer/tests/test_cmd_ingest.py
+++ b/src/observer/tests/test_cmd_ingest.py
@@ -3,6 +3,7 @@ from os.path import join
 import json
 from .base import BaseCase, call_command
 from observer import models, utils
+from unittest import skip
 
 class LoadFromFS(BaseCase):
     def setUp(self):
@@ -38,6 +39,8 @@ class LoadFromFS(BaseCase):
         self.assertEqual(errcode, 1)
         self.assertEqual(models.Article.objects.count(), 0)
 
+    @skip("test is obsolete as ingestion has changed from scraping each article version in "
+          "order to scraping 'an article' with article version fixtures from database")
     def test_ingest_from_cli_bad_article(self):
         self.assertEqual(models.Article.objects.count(), 0)
         data = json.load(open(self.ajson_fixture, 'r'))

--- a/src/observer/tests/test_logic.py
+++ b/src/observer/tests/test_logic.py
@@ -1,0 +1,15 @@
+from . import base
+from observer import logic, ingest_logic, models
+
+class One(base.BaseCase):
+    def setUp(self):
+        pass
+
+    def test_known_articles(self):
+        "a list of article manuscript IDs are returned as integers, highest to lowest"
+        for i in range(1, 12):
+            ingest_logic.upsert_ajson(i, 1, models.LAX_AJSON, {})
+        # without the casting in logic.known_articles, you get ordering like this:
+        # ['9', '8', '7', '6', '5', '4', '3', '2', '11', '10', '1']
+        expected = [11, 10, 9, 8, 7, 6, 5, 4, 3, 2, 1]
+        self.assertEqual(expected, list(logic.known_articles()))

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -58,7 +58,7 @@ class Two(BaseCase):
     def setUp(self):
         self.c = Client()
         for path in listfiles(join(self.fixture_dir, 'ajson'), ['.json']):
-            ingest_logic.file_upsert(path)
+            ingest_logic.file_upsert(path, regen=False)
         ingest_logic.regenerate_all()
 
     def tearDown(self):
@@ -97,7 +97,7 @@ class Two(BaseCase):
         self.assertEqual(reduce(rdf, date_list), date_list[-1])
 
     def test_report_ordered_reverse(self):
-        "ensure report is ordered correctly"
+        "ensure report is ordered correctly. reports are ordered by original date published"
         url = reverse('report', kwargs={'name': 'latest-articles'})
         resp = self.c.get(url, {'order': 'ASC'})
         xml = resp.content.decode('utf-8')

--- a/src/observer/utils.py
+++ b/src/observer/utils.py
@@ -224,7 +224,7 @@ def create_or_update(Model, orig_data, key_list=None, create=True, update=True, 
 def save_objects(queue):
     """complements create_or_update(), saves a list of pairs of (parent, children-list)
     each parent and each child are the kwargs to be passed to `create_or_update`.
-    each child requires an extra kwarg 'parent-relation' which will be used to 'attach' the 
+    each child requires an extra kwarg 'parent-relation' which will be used to 'attach' the
     child to the parent."""
     for parent_kwargs, children in queue:
         ensure(isinstance(children, list), "'children' must be a list.")

--- a/src/observer/utils.py
+++ b/src/observer/utils.py
@@ -222,13 +222,10 @@ def create_or_update(Model, orig_data, key_list=None, create=True, update=True, 
     return (inst, created, updated)
 
 def save_objects(queue):
-    """saves a list of objects, or list of pairs of name:objects. complements create_or_update().
-    each item in queue is either a dictionary of keyword arguments to create_or_update or a list
-    of pairs like (relation name, create_or_update kwargs).
-    each object is saved in order and lists of pairs are treated as children to the previous object.
-    children are saved as: previous-object.relation = list-of-children
-
-    deeply nested children are not possible"""
+    """complements create_or_update(), saves a list of pairs of (parent, children-list)
+    each parent and each child are the kwargs to be passed to `create_or_update`.
+    each child requires an extra kwarg 'parent-relation' which will be used to 'attach' the 
+    child to the parent."""
     for parent_kwargs, children in queue:
         ensure(isinstance(children, list), "'children' must be a list.")
         parent = create_or_update(**parent_kwargs)[0]


### PR DESCRIPTION
Observer is suffering sporadic database deadlocks errors, especially when under load.

This branch is attempting to shift a chunk of work out of the transaction

ticket: https://elifesciences.atlassian.net/browse/ELPP-3489

