### PR TITLE
[wip] bug fixes, ELPP-3699

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ Articles published by eLife, filtered by given subjects
 * [RSS](/report/latest-articles-by-subject.rss), [CSV](/report/latest-articles-by-subject.csv)  formats
 * ordered by date and time this article was _first_ published (_most_ recent to least recent)
 * 28 articles per page (default) [50pp](/report/latest-articles-by-subject?per-page=50) [100pp](/report/latest-articles-by-subject?per-page=100)
-* accepts these extra parameters: subject () 
+* accepts these extra parameters: subject (cancer-biology, cell-biology, epidemiology-global-health, genes-chromosomes, genomics-evolutionary-biology, human-biology-medicine)
 
 #### upcoming articles report
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ or, as a simple format hint:
 All of the latest articles published at eLife, including in-progress POA (publish-on-accept) articles.
 
 * [RSS](/report/latest-articles.rss), [CSV](/report/latest-articles.csv)  formats
-* ordered by date and time this _version_ of article was published (_most_ recent to least recent)
+* ordered by date and time this article was _first_ published (_most_ recent to least recent)
 * 28 articles per page (default) [50pp](/report/latest-articles?per-page=50) [100pp](/report/latest-articles?per-page=100)
 
 #### latest articles by subject report
@@ -56,16 +56,16 @@ All of the latest articles published at eLife, including in-progress POA (publis
 Articles published by eLife, filtered by given subjects
 
 * [RSS](/report/latest-articles-by-subject.rss), [CSV](/report/latest-articles-by-subject.csv)  formats
-* ordered by date and time this _version_ of article was published (_most_ recent to least recent)
+* ordered by date and time this article was _first_ published (_most_ recent to least recent)
 * 28 articles per page (default) [50pp](/report/latest-articles-by-subject?per-page=50) [100pp](/report/latest-articles-by-subject?per-page=100)
-* accepts these extra parameters: subject (cancer-biology, cell-biology, epidemiology-global-health, genes-chromosomes, genomics-evolutionary-biology, human-biology-medicine) 
+* accepts these extra parameters: subject () 
 
 #### upcoming articles report
 
 The latest eLife POA (publish-on-accept) articles. These articles are in-progress and their final VOR (version-of-record) is still being produced.
 
 * [RSS](/report/upcoming-articles.rss), [CSV](/report/upcoming-articles.csv)  formats
-* ordered by date and time this _version_ of article was published (_most_ recent to least recent)
+* ordered by date and time this article was _first_ published (_most_ recent to least recent)
 * 28 articles per page (default) [50pp](/report/upcoming-articles?per-page=50) [100pp](/report/upcoming-articles?per-page=100)
 
 #### published research article index report
@@ -74,6 +74,13 @@ The dates and times of publication for all _research_ articles published at eLif
 
 * [CSV](/report/published-research-article-index.csv)  formats
 * ordered by eLife manuscript ID (_least_ recent to most recent)
+
+#### daily profile counts report
+
+Daily record of the total number of profiles
+
+* [CSV](/report/profile-count.csv)  formats
+* ordered by year, month and day (_most_ recent to least recent)
 
 ## installation
 

--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -158,9 +158,7 @@ DESC = {
     # 'published' doesn't change, ever. it's the v1 pubdate
     'datetime_published': [p('published'), todt],
     # 'versionDate' changes on every single version
-    # TODO: data bug!
-    #'datetime_version_published': [p('versionDate'), todt], # correct
-    'datetime_version_published': [p('published'), todt],
+    'datetime_version_published': [p('versionDate'), todt],
     # poa pubdate is the date the state changed to POA, if any POA present
     'datetime_poa_published': [known_versions(POA), first, _or({}), p('statusDate', EXCLUDE_ME), todt],
     # vor pubdate is the date the state changed to VOR, if any VOR present

--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -57,9 +57,7 @@ def calc_pub_to_current(art):
     if not kv or len(kv) == 1:
         return None # cannot be calculated
     v1dt = todt(first(kv)['published'])
-    # TODO: data bug!
-    # vNdt = todt(last(kv)['versionDate']) # this is correct
-    vNdt = todt(last(kv)['published'])
+    vNdt = todt(last(kv)['versionDate'])
     return (vNdt - v1dt).days
 
 #

--- a/src/observer/reports.py
+++ b/src/observer/reports.py
@@ -31,7 +31,10 @@ def article_meta(**kwargs):
     "returns standard metadata most reports returning models.Article objects will need"
     meta = {
         'serialisations': [RSS, CSV],
-        'order_by': 'datetime_version_published',
+        # 2018-06-27: changed from 'datetime_version_published' to 'datetime_published'
+        # there was a bug where the field 'datetime_version_published' was being set to the 'datetime_published' value
+        # this change preserves the behaviour that has been in service for ~12 months now
+        'order_by': 'datetime_published',
         'order': DESC,
         'per_page': 28,
         'params': None
@@ -154,6 +157,7 @@ def known_report_idx():
 
 def _report_meta(reportfn):
     labels = {
+        'datetime_published': 'date and time this article was _first_ published',
         'datetime_version_published': 'date and time this _version_ of article was published',
         'msid': 'eLife manuscript ID',
         'day': 'year, month and day',

--- a/src/observer/tests/test_ingest_logic.py
+++ b/src/observer/tests/test_ingest_logic.py
@@ -261,6 +261,17 @@ class AggregateLogic(BaseCase):
         # 18675 v1,v2,v3,v4
         logic.bulk_file_upsert(join(self.fixture_dir, 'ajson'))
 
+    def test_calc_pub_to_current(self):
+        cases = [
+            # (msid, expected days)
+            # (13964, # is actually fubar
+            (15378, 35), # days
+            (18675, 24), # days
+        ]
+        for msid, expected_num_days in cases:
+            art = models.Article.objects.get(msid=msid)
+            self.assertEqual(expected_num_days, art.days_publication_to_current_version)
+
     def test_num_authors(self):
         expected_authors = {
             '13964': 24,

--- a/src/observer/tests/test_ingest_logic.py
+++ b/src/observer/tests/test_ingest_logic.py
@@ -4,6 +4,8 @@ from .base import BaseCase
 from observer import ingest_logic as logic, models, utils
 from unittest.mock import patch
 from observer.ingest_logic import p, pp
+from datetime import datetime
+import pytz
 
 class Logic(BaseCase):
     def setUp(self):
@@ -304,6 +306,19 @@ class AggregateLogic(BaseCase):
                 print('failed on', msid, 'with vers', vers)
                 raise err
 
+    def test_datetime_version_published(self):
+        "this field is the date of the most recent version of this article"
+        cases = [
+            (13964, datetime(year=2016, month=6, day=15, tzinfo=pytz.utc)),
+            (14850, datetime(year=2016, month=7, day=21, tzinfo=pytz.utc)),
+            (15378, datetime(year=2016, month=9, day=2, hour=14, minute=51, second=0, tzinfo=pytz.utc)),
+            (18675, datetime(year=2016, month=9, day=16, hour=10, minute=13, second=54, tzinfo=pytz.utc)),
+            (20125, datetime(year=2016, month=9, day=8, tzinfo=pytz.utc)),
+        ]
+        for msid, expected_version_date in cases:
+            art = models.Article.objects.get(msid=msid)
+            self.assertEqual(expected_version_date, art.datetime_version_published)
+            
     def test_calc_poa_published(self):
         poa_pubdates = {
             '13964': '2016-05-16T00:00:00Z',


### PR DESCRIPTION
* fixes bug#1, the calculation of pubdate to latest versionDate
* fixes bug#2, the value of field datetime_version_published
* preserves the existing behaviour of reports by changing the default ordering of reports  from datetime_version_published to datetime_published

ticket: https://elifesciences.atlassian.net/browse/ELPP-3630