### PR TITLE
django, 2.2 upgrade.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,4 +15,3 @@ app.cfg
 uwsgi.ini
 ingestion-lax.log.json
 /src/core/prod_settings.py
-_venv

--- a/Pipfile
+++ b/Pipfile
@@ -23,7 +23,7 @@ pytz = "*"
 requests = "~=2.20"
 requests-cache = "==0.4.13"
 rfc3339 = "==6.0"
-Django = "==1.11.29"
+Django = "==2.2.*"
 uWSGI = "*"
 
 [dev-packages]

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "3a157723b3981a59b4701e7c91efa4c0c5098e9545492639429a6b0bf4cdda9a"
+            "sha256": "116e30c17e9736c929913aeeb101ad0fe50fbcc64b78913fe9789109a8aa1036"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -55,11 +55,11 @@
         },
         "django": {
             "hashes": [
-                "sha256:014e3392058d94f40569206a24523ce254d55ad2f9f46c6550b0fe2e4f94cf3f",
-                "sha256:4200aefb6678019a0acf0005cd14cfce3a5e6b9b90d06145fcdd2e474ad4329c"
+                "sha256:62cf45e5ee425c52e411c0742e641a6588b7e8af0d2c274a27940931b2786594",
+                "sha256:83ced795a0f239f41d8ecabf51cc5fad4b97462a6008dc12e5af3cb9288724ec"
             ],
             "index": "pypi",
-            "version": "==1.11.29"
+            "version": "==2.2.16"
         },
         "django-annoying": {
             "hashes": [
@@ -262,6 +262,14 @@
             ],
             "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
             "version": "==1.15.0"
+        },
+        "sqlparse": {
+            "hashes": [
+                "sha256:022fb9c87b524d1f7862b3037e541f68597a730a8843245c349fc93e1643dc4e",
+                "sha256:e162203737712307dfe78860cc56c8da8a852ab2ee33750e33aeadf38d12c548"
+            ],
+            "markers": "python_version >= '2.7' and python_version not in '3.0, 3.1, 3.2, 3.3'",
+            "version": "==0.3.1"
         },
         "unidecode": {
             "hashes": [

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ certifi==2020.6.20
 chardet==3.0.4
 colorama==0.4.3
 coverage==4.5.4
-Django==1.11.29
+Django==2.2.16
 django-annoying==0.10.6
 django-markdown2==0.3.1
 et3==1.5.1
@@ -38,6 +38,7 @@ requests-cache==0.4.13
 rfc3339==6.0
 s3transfer==0.3.3
 six==1.15.0
+sqlparse==0.3.1
 toml==0.10.1
 typed-ast==1.4.1
 Unidecode==1.1.1

--- a/src/core/settings.py
+++ b/src/core/settings.py
@@ -72,9 +72,6 @@ MIDDLEWARE = [
 
 ROOT_URLCONF = 'core.urls'
 
-# https://docs.djangoproject.com/en/1.10/ref/middleware/#module-django.middleware.common
-USE_ETAGS = True
-
 TEMPLATES = [
     {
         'BACKEND': 'django.template.backends.django.DjangoTemplates',

--- a/src/core/tests.py
+++ b/src/core/tests.py
@@ -12,7 +12,6 @@ class DownstreamCaching(TestCase):
     def test_cache_headers_in_response(self):
         expected_headers = [
             'vary', # redundant
-            'etag',
             'cache-control'
         ]
         resp = self.c.get(self.url)

--- a/src/observer/rss.py
+++ b/src/observer/rss.py
@@ -73,7 +73,7 @@ def article_to_rss_entry(art):
     utils.renkeys(item, [
         ('doi', 'link'),
         ('abstract', 'description'),
-        ('datetime_published', 'pubdate'),
+        ('datetime_published', 'pubDate'),
     ])
 
     # wrangle
@@ -81,7 +81,7 @@ def article_to_rss_entry(art):
     item['link'] = {'href': "https://elifesciences.org/articles/" + utils.pad_msid(art.msid)}
     item['author'] = [{'name': a.name, 'email': art.author_email} for a in art.authors.all()]
     item['category'] = [{'term': c.name, 'label': c.label} for c in art.subjects.all()]
-    item['dc:dc_date'] = utils.ymdhms(item['pubdate'])
+    item['dc:dc_date'] = utils.ymdhms(item['pubDate'])
     return item
 
 def format_report(report, context):

--- a/src/observer/tests/test_csv_views.py
+++ b/src/observer/tests/test_csv_views.py
@@ -1,11 +1,7 @@
-#from functools import reduce
-#from datetime import datetime
-#from observer.utils import listfiles
-#import re
 from os.path import join
 from .base import BaseCase
 from django.test import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from observer import ingest_logic, csv, reports
 from observer.utils import listfiles
 

--- a/src/observer/tests/test_json_lines.py
+++ b/src/observer/tests/test_json_lines.py
@@ -3,7 +3,7 @@ from os.path import join
 from . import base
 from observer import utils, ingest_logic
 from django.test import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 
 class JsonLinesResponse(base.BaseCase):
     def setUp(self):

--- a/src/observer/tests/test_reports.py
+++ b/src/observer/tests/test_reports.py
@@ -3,7 +3,7 @@ from .base import BaseCase
 from observer import reports, ingest_logic, models, utils
 from observer.utils import todt
 from django.test import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from unittest import mock
 from datetime import datetime, timedelta
 

--- a/src/observer/tests/test_rss_views.py
+++ b/src/observer/tests/test_rss_views.py
@@ -4,7 +4,7 @@ import re
 from os.path import join
 from .base import BaseCase
 from django.test import Client
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from observer import ingest_logic, models
 from observer.utils import lmap
 
@@ -131,6 +131,13 @@ class Two(BaseCase):
         paginate = 1
         csv_peek = 1
         csv_generation = 1
-        num = paginate + csv_peek + csv_generation
+        #num = paginate + csv_peek + csv_generation
+        # 2020-09: changed in Django 2.0
+        # two additional queries are now happening in the CSV version of this report, one for Author and one for Subject.
+        # this is possibly because of new support for foreign key constraints in SQLite and those tables are now properly join'ed
+        # causing two additional queries. If so, this means that postgresql has been doing five queries all along
+        author_lu = 1
+        subject_lu = 1
+        num = paginate + csv_peek + csv_generation + author_lu + subject_lu
         with self.assertNumQueries(num):
             self.c.get(reverse('report', kwargs={'name': 'latest-articles'}), {'format': 'csv'})

--- a/src/observer/tests/test_views.py
+++ b/src/observer/tests/test_views.py
@@ -2,7 +2,7 @@ from os.path import join
 from django.test import Client
 from .base import BaseCase
 from observer import reports, ingest_logic, models, utils
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from observer.utils import listfiles, lmap
 from functools import reduce, partial
 

--- a/src/observer/views.py
+++ b/src/observer/views.py
@@ -1,5 +1,5 @@
 from datetime import date
-from django.core.urlresolvers import reverse
+from django.urls import reverse
 from django.http import HttpResponse
 from django.template.loader import render_to_string
 from django.shortcuts import Http404  # , get_object_or_404


### PR DESCRIPTION
fixes pubdate vs pubDate deprecation in feedgen.
updates report test with new query count after behaviour change in 2.0