### PR TITLE
fixed bug due to mismatch in generating a RawJSON json_type key.

### DIFF
--- a/src/observer/consume.py
+++ b/src/observer/consume.py
@@ -65,23 +65,23 @@ def consume(endpoint, user_params={}):
 def default_idfn(row):
     return row['id']
 
-def upsert(iid, content_type, content):
+def upsert(iid, json_type, content):
     data = {
         'msid': iid,
         'version': None,
         'json': content,
-        'json_type': content_type
+        'json_type': json_type
     }
     return utils.create_or_update(models.RawJSON, data, ['msid', 'json_type'])
 
-def upsert_all(content_type, rows, idfn):
+def upsert_all(json_type, rows, idfn):
     def do_safely(row):
         try:
             item_id = idfn(row)
         except Exception:
             LOG.error("failed to extract item id from row: %s", row)
             return
-        return upsert(item_id, content_type, row)
+        return upsert(item_id, json_type, row)
 
     with transaction.atomic():
         utils.lmap(do_safely, rows)
@@ -91,25 +91,52 @@ def upsert_all(content_type, rows, idfn):
 # generic content consumption
 #
 
+# todo: this was such a bad idea. figure out how to get rid of it.
 def content_type_from_endpoint(endpoint):
     """given an API `endpoint` like `press-packages/{id}`, returns a slugified version like `press-packages-id`.
-    if the given API `endpoint` doesn't exist in the alias map, it's value is returned as-is.
-    for example, `digests` is aliased `digests-id`."""
-    val = slugify(endpoint) # press-packages/{id} => press-packages-id
-    aliases = {
-        # summary endpoints
-        'community': models.COMMUNITY,
-        'labs-posts': models.LABS_POST,
-        'profiles': models.PROFILE,
-        'press-packages': models.PRESSPACKAGE,
-        'digests': models.DIGEST,
-        'podcast-episodes': models.PODCAST,
+    if the given API `endpoint` doesn't exist in the alias map, it's value is returned as-is."""
 
-        # backwards support
-        'articles-id-versions-version': models.LAX_AJSON,
-        'metrics-article-summary': models.METRICS_SUMMARY
+    # "press-packages/{id}" => "press-packages-id", "interviews" => "interviews"
+    val = slugify(endpoint)
+    aliases = {
+        # models.PODCAST == 'podcast' and not 'podcast-episode' :(
+        'podcast-episodes': models.PODCAST,
+        'podcast-episodes/{id}': models.PODCAST,
+
+        # models.PRESSPACKAGE == 'press-packages-id' :(
+        'press-packages-id': models.PRESSPACKAGE,
+        'press-packages': models.PRESSPACKAGE,
+
+        # models.PROFILE == 'profiles-id' :(
+        # as of 2022-01-31 we have 47k 'profiles-id' in RawJSON
+        'profiles': models.PROFILE,
+        'profiles-id': models.PROFILE,
+
+        # "/articles/{id}/versions/{version}"
+        'articles-id-versions-version': models.LAX_AJSON, # 'lax-ajson'
+
+        # "/metrics/article-summary" (non-api)
+        'metrics-article-summary': models.METRICS_SUMMARY, # 'elife-metrics-summary'
     }
-    return aliases.get(val, val)
+    alias = aliases.get(slugify(endpoint))
+    if alias:
+        return alias
+
+    # at this point val will either be an alias as above, or something like "/profiles/{id}"
+    # we don't want "foo-id" with the "-id" suffix *at all*
+
+    val = val.strip("/") # just in case. "/digests/{id}" => "digests/{id}"
+
+    # at this point val will either be "digests" (api summary) or "digests/{id}" (api detail)
+    if "/" in val:
+        val = val[:val.index("/")] # "digests/{id}" => "digests"
+
+    # now, we don't want the plural version stored in the database, we use the singular internally
+    # i.e. models.DIGEST is 'digest' not 'digests'
+
+    val = val.rstrip('s')
+
+    return val
 
 def single(endpoint, idfn=None, **kwargs):
     "consumes a single item from the API `endpoint` and creates/inserts it into the database."
@@ -136,7 +163,7 @@ def all_items(endpoint, idfn=None, **kwargs):
     content_type = content_type_from_endpoint(endpoint)
 
     accumulator = []
-    accumulate = 100 # accumulate 10 pages before inserting
+    accumulate = 100 # accumulate n pages before inserting
     for page in range(1, num_pages + 1):
         try:
             resp = consume(endpoint, {'page': page, 'per-page': per_page})

--- a/src/observer/consume.py
+++ b/src/observer/consume.py
@@ -91,17 +91,17 @@ def upsert_all(json_type, rows, idfn):
 # generic content consumption
 #
 
-# todo: this was such a bad idea. figure out how to get rid of it.
+# lsh@2022-02-01: this was such a bad idea. figure out how to get rid of it.
 def content_type_from_endpoint(endpoint):
-    """given an API `endpoint` like `press-packages/{id}`, returns a slugified version like `press-packages-id`.
-    if the given API `endpoint` doesn't exist in the alias map, it's value is returned as-is."""
+    """given an API endpoint like `press-packages/{id}` returns the singular value matching the constants in `models`.
+    some endpoints are hardcoded to handle values that can't be derived."""
 
     # "press-packages/{id}" => "press-packages-id", "interviews" => "interviews"
     val = slugify(endpoint)
     aliases = {
         # models.PODCAST == 'podcast' and not 'podcast-episode' :(
         'podcast-episodes': models.PODCAST,
-        'podcast-episodes/{id}': models.PODCAST,
+        'podcast-episodes-id': models.PODCAST,
 
         # models.PRESSPACKAGE == 'press-packages-id' :(
         'press-packages-id': models.PRESSPACKAGE,
@@ -118,16 +118,14 @@ def content_type_from_endpoint(endpoint):
         # "/metrics/article-summary" (non-api)
         'metrics-article-summary': models.METRICS_SUMMARY, # 'elife-metrics-summary'
     }
-    alias = aliases.get(slugify(endpoint))
+    alias = aliases.get(val)
     if alias:
         return alias
 
-    # at this point val will either be an alias as above, or something like "/profiles/{id}"
-    # we don't want "foo-id" with the "-id" suffix *at all*
-
-    val = val.strip("/") # just in case. "/digests/{id}" => "digests/{id}"
-
     # at this point val will either be "digests" (api summary) or "digests/{id}" (api detail)
+    # we don't want "foo-id" with the "-id" suffix anywhere.
+
+    val = val.strip("/") # in case of a leading slash. "/digests/{id}" => "digests/{id}"
     if "/" in val:
         val = val[:val.index("/")] # "digests/{id}" => "digests"
 

--- a/src/observer/inc.py
+++ b/src/observer/inc.py
@@ -48,8 +48,8 @@ def _handler(json_event):
     # see: https://github.com/elifesciences/bus
     # and: https://github.com/elifesciences/builder/blob/master/projects/elife.yaml#L1166
 
-    # because the event-type may not be identical to what is used internally,
-    # map all supported types here and comment them out as necessary
+    # 'event-type' may not match what is used internally.
+    # map supported types here and comment others out as necessary.
     event_type_to_content_type = {
         'article': models.LAX_AJSON,
         'presspackage': models.PRESSPACKAGE,

--- a/src/observer/logic.py
+++ b/src/observer/logic.py
@@ -3,10 +3,10 @@ from observer import models
 from django.db.models import IntegerField
 from django.db.models.functions import Cast
 
-def known_content(content_type):
+def known_content(json_type):
     """returns a queryset of object IDs from newest to oldest."""
     return models.RawJSON.objects \
-        .filter(json_type=content_type) \
+        .filter(json_type=json_type) \
         .values_list('msid', flat=True) \
         .order_by('-msid') \
         .distinct()

--- a/src/observer/models.py
+++ b/src/observer/models.py
@@ -13,7 +13,6 @@ LAX_AJSON = 'lax-ajson'
 METRICS_SUMMARY = 'elife-metrics-summary'
 PRESSPACKAGE = 'press-packages-id'
 PROFILE = 'profiles-id'
-# DIGEST = 'digests-id' # old, do not use, remove once RawJSON in db is removed
 
 DIGEST = 'digest'
 LABS_POST = 'labs-post'

--- a/src/observer/tests/test_inc.py
+++ b/src/observer/tests/test_inc.py
@@ -71,7 +71,7 @@ def test_404_deletes_item():
     response.status_code = 404
     exc = requests.exceptions.RequestException()
     exc.response = response
-    with patch('observer.ingest_logic.download_item', side_effect=exc): # prevent downloading other versions
+    with patch('observer.ingest_logic.download_item', side_effect=exc):
         inc.handler(dummy_event)
 
     assert models.Content.objects.count() == 0


### PR DESCRIPTION
the consume.content_type_from_endpoint function was returning values with '-id' suffixed to them in some cases, so while content could be successfully fetched and inserted into RawJSON by consume, regenerating the item in ingest_logic.py would fail to find it and cause an uncaught DoesNotExist error.
I've rejigged the 'content_type_from_endpoint' function to hardcode some paths that don't align with constants not used internally and the other derived values now match the other constants.


- [x] review