### PR TITLE
daily.sh, re-enables metrics scrape.

### DIFF
--- a/daily.sh
+++ b/daily.sh
@@ -4,5 +4,4 @@
 # other content types (articles, presspackages, digests, etc) are updated via the message bus.
 # `load_from_api` is able to do adhoc imports of any content though.
 
-#./manage.sh load_from_api --target profiles elife-metrics community
-./manage.sh load_from_api --target profiles community
+./manage.sh load_from_api --target profiles elife-metrics community


### PR DESCRIPTION
elife-metrics db hasn't been improved to handle extra load