### PR TITLE
ingest logic, unsupport content type is now skipped and an error emitted

### DIFF
--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -673,11 +673,14 @@ def _regenerate_item(content_type, content_id, data=None):
     if 'content-type-fn' in content_descriptions[content_type]:
         content_type = content_descriptions[content_type]['content-type-fn'](data)
 
-    # if not content_type in content_descriptions:
-    #    print("skipping unhandled content type %r" % content_type)
-    #    return
-
-    assert content_type in content_descriptions, "unhandled content type %r" % content_type
+    # lsh@2022-03-21: disabled assertion and enabled this section.
+    # /community was returning 'event' content types and dying mid-regeneration.
+    # observer shouldn't be encountering any unsupported content.
+    # in this case, it looks like it was accidental but was stored in RawJSON.
+    if not content_type in content_descriptions:
+        LOG.error("skipping unhandled content type %r. this may need to be deleted from the database: %s" % (content_type, data))
+        return
+    #assert content_type in content_descriptions, "unhandled content type %r: %s" % (content_type, data)
 
     mush = flatten_data(content_type, data)
     mush, children = extract_children(mush)

--- a/src/observer/tests/fixtures/unknown/content.json
+++ b/src/observer/tests/fixtures/unknown/content.json
@@ -1,0 +1,14 @@
+{
+  "total": 1,
+  "items": [
+    {
+        "ends": "2020-11-25T17:30:00Z",
+        "id": "cf5bc216",
+        "impactStatement": "Join us to learn more about the challenges ECRs and underrepresented groups face when pursuing funding opportunities and hear about examples of how funding could be made fairer.",
+        "published": "2020-11-16T09:15:28Z",
+        "starts": "2020-11-25T16:00:00Z",
+        "title": "#ECRWednesday Webinar: In pursuit of more equitable funding",
+        "type": "event"
+    }
+  ]
+}

--- a/src/observer/tests/test_ingest_logic.py
+++ b/src/observer/tests/test_ingest_logic.py
@@ -528,3 +528,12 @@ def test_delete_items__failure_cases():
     ]
     for content_type, content_id, expected in cases:
         assert ingest_logic.delete_item(content_type, content_id) == expected, "failed case %r" % str(content_type, content_id, expected)
+
+@pytest.mark.django_db
+def test_unsupported_content_type_skipped():
+    fixture = base.jsonfix('unknown/content.json')
+    with patch('observer.consume.consume', return_value=fixture):
+        ingest_logic.download_all(models.COMMUNITY)
+    assert models.RawJSON.objects.count() == 1
+    ingest_logic.regenerate(models.COMMUNITY)
+    assert models.Content.objects.count() == 0


### PR DESCRIPTION
the content will need to be deleted from the RawJSON table manually.