### PR TITLE
ingest_logic.py, fixed bug 

### DIFF
--- a/src/observer/inc.py
+++ b/src/observer/inc.py
@@ -37,7 +37,7 @@ def _handler(json_event):
         # parse event
         LOG.info("handling event %s" % json_event)
         event = json.loads(json_event)
-        # rule: event id will always be a string
+        # business rule: event type id will always be a string
         event_type = event['type']
         if event_type == 'podcast-episode':
             event_id = event['number']

--- a/src/observer/ingest_logic.py
+++ b/src/observer/ingest_logic.py
@@ -724,8 +724,10 @@ def regenerate(content_type):
     return regenerate_list(content_type, logic.known_content(json_type=content_type))
 
 def download_item(content_type, content_id):
-    api = CONTENT_DESCRIPTIONS[content_type]['api-item']
-    return first(consume.single(api, id=content_id))
+    content_description = CONTENT_DESCRIPTIONS[content_type]
+    api = content_description['api-item']
+    idfn = content_description.get('idfn', consume.default_idfn)
+    return first(consume.single(api, id=content_id, idfn=idfn))
 
 def download_all(content_type, alt_content_description_map=None, **kwargs):
     """downloads *all* pages of content for the given `content_type`.

--- a/src/observer/tests/test_inc.py
+++ b/src/observer/tests/test_inc.py
@@ -44,6 +44,28 @@ def test_handling_event():
             inc.handler(dummy_event)
             assert mock.called, "not called for %r" % event
 
+def test_handling_bad_events():
+    "malformed events can be handled without issue."
+    cases = [
+        # string ids when they should be numeric
+        {'type': 'article', 'id': "1"},
+        {'type': 'presspackage', 'id': "2"},
+        {'type': 'labs-post', 'id': "3"},
+        {'type': 'digest', 'id': "4"},
+        {'type': 'podcast-episode', 'number': "5"},
+        {'type': 'collection', 'id': "6"},
+        {'type': 'interview', 'id': "7"},
+        {'type': 'blog-article', 'id': "8"},
+
+        # ...
+    ]
+    for event in cases:
+        dummy_event = Mock()
+        dummy_event.body = json.dumps(event)
+        with patch('observer.ingest_logic.download_regenerate') as mock:
+            inc.handler(dummy_event)
+            assert mock.called, "not called for %r" % event
+
 def test_handling_unhandled_event():
     "unhandled events should issue a warning"
     dummy_event = Mock()

--- a/src/observer/tests/test_ingest_logic.py
+++ b/src/observer/tests/test_ingest_logic.py
@@ -537,3 +537,20 @@ def test_unsupported_content_type_skipped():
     assert models.RawJSON.objects.count() == 1
     ingest_logic.regenerate(models.COMMUNITY)
     assert models.Content.objects.count() == 0
+
+@pytest.mark.django_db
+def test_download_with_idfn():
+    pid = "7"
+    data = {
+        "number": 7,
+        "title": "Episode 7: December 2013",
+        "impactStatement": "In this episode we hear about drug resistance, severe brain damage, sugar versus sweetener, public goods dilemmas, and the evolution of the machinary that makes proteins in cells.",
+        "published": "2014-01-09T13:45:10Z",
+        "image": {"thumbnail": {"uri": "foo", "size": {"height": 100, "width": 100}, "source": {"mediaType": "image/jpeg"}}}
+    }
+    with patch('observer.consume.consume', return_value=data):
+        ingest_logic.download_item(models.PODCAST, pid)
+        assert models.RawJSON.objects.count() == 1
+
+        ingest_logic.regenerate(models.PODCAST)
+        assert models.Content.objects.count() == 1


### PR DESCRIPTION
where consume single was not passing the 'idfn' needed to extract the 'id' value from the response data.

- [x] test
- [x] review